### PR TITLE
Make sure unicode string literals are used in line processing

### DIFF
--- a/src/pybel/resources/document.py
+++ b/src/pybel/resources/document.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function, unicode_literals
+from builtins import dict, str
 
 import hashlib
 import itertools as itt

--- a/src/pybel/resources/document.py
+++ b/src/pybel/resources/document.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, print_function, unicode_literals
-from builtins import dict, str
 
 import hashlib
 import itertools as itt


### PR DESCRIPTION
Fixes #288 but not sure if it has any other effects I'm not aware of (hopefully tests will tell). This adds a little more than what is strictly necessary but these two lines are a good "header" to have pretty much in every file for Python 2/3 cross-compatibility.