### PR TITLE
Use setuptools platform dependency specifications instead of an if st…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,13 +38,11 @@ INSTALL_REQUIRES = [
     'pyparsing',
     'six',
     'tqdm',
+    'configparser; python_version < "3"',
+    'enum34; python_version < "3"',  # Only necessary for NDEx?
+    'functools32; python_version < "3"',
+    'funcsigs; python_version < "3"',
 ]
-
-if sys.version_info < (3, ):
-    INSTALL_REQUIRES.append('configparser')
-    INSTALL_REQUIRES.append('enum34')  # Only necessary for NDEx?
-    INSTALL_REQUIRES.append('functools32')
-    INSTALL_REQUIRES.append('funcsigs')
 
 EXTRAS_REQUIRE = {
     'indra': ['indra'],

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ INSTALL_REQUIRES = [
     'six',
     'tqdm',
     'configparser; python_version < "3"',
-    'enum34; python_version < "3"',  # Only necessary for NDEx?
     'functools32; python_version < "3"',
     'funcsigs; python_version < "3"',
 ]


### PR DESCRIPTION
…atement for requirements that are only needed in certain versions of Python.