### PR TITLE
Python3 print() for graph_summary.py

### DIFF
--- a/src/pybel/struct/summary/graph_summary.py
+++ b/src/pybel/struct/summary/graph_summary.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
+
 """Graph summary functions."""
 
 import logging


### PR DESCRIPTION
Line 66 invokes print as a function

This was spotted while creating a Debian package for it, which would otherwise not install.