### PR TITLE
Update installation docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ or from the latest code on `GitHub <https://github.com/pybel/pybel>`_ with:
 
     $ pip install git+https://github.com/pybel/pybel.git
 
-See the `installation documentation <http://pybel.readthedocs.io/en/latest/installation.html>`_ for more advanced
+See the `installation documentation <https://pybel.readthedocs.io/en/latest/introduction/installation.html>`_ for more advanced
 instructions. Also, check the change log at `CHANGELOG.rst <https://github.com/pybel/pybel/blob/master/CHANGELOG.rst>`_.
 
 Getting Started

--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,8 @@ or from the latest code on `GitHub <https://github.com/pybel/pybel>`_ with:
 See the `installation documentation <https://pybel.readthedocs.io/en/latest/introduction/installation.html>`_ for more advanced
 instructions. Also, check the change log at `CHANGELOG.rst <https://github.com/pybel/pybel/blob/master/CHANGELOG.rst>`_.
 
+Note: while PyBEL works on the most recent versions of Python 3.5, it does not work on 3.5.3 or below due to changes in the ``typing`` module.
+
 Getting Started
 ---------------
 More examples can be found in the `documentation <http://pybel.readthedocs.io>`_ and in the

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,8 @@ or from the latest code on `GitHub <https://github.com/pybel/pybel>`_ with:
 See the `installation documentation <https://pybel.readthedocs.io/en/latest/introduction/installation.html>`_ for more advanced
 instructions. Also, check the change log at `CHANGELOG.rst <https://github.com/pybel/pybel/blob/master/CHANGELOG.rst>`_.
 
-Note: while PyBEL works on the most recent versions of Python 3.5, it does not work on 3.5.3 or below due to changes in the ``typing`` module.
+Note: while PyBEL works on the most recent versions of Python 3.5, it does not work on 3.5.3 or below due to changes
+in the ``typing`` module.
 
 Getting Started
 ---------------

--- a/docs/source/introduction/installation.rst
+++ b/docs/source/introduction/installation.rst
@@ -55,7 +55,7 @@ jupyter
 ~~~~~~~
 This extra installs support for visualizing BEL graphs in Jupyter notebooks.
 
-.. seealso:: 
+.. seealso::
 
     - :func:`pybel.io.jupyter.to_html`
     - :func:`pybel.io.jupyter.to_jupyter`

--- a/docs/source/introduction/installation.rst
+++ b/docs/source/introduction/installation.rst
@@ -25,8 +25,8 @@ Extras
 ------
 The ``setup.py`` makes use of the ``extras_require`` argument of :func:`setuptools.setup` in order to make some heavy
 packages that support special features of PyBEL optional to install, in order to make the installation more lean by
-default. A single extra can be installed from PyPI like :code:`python3 -m pip install -e pybel[neo4j]` or multiple can
-be installed using a list like :code:`python3 -m pip install -e pybel[neo4j,inra]`. Likewise, for developer
+default. A single extra can be installed from PyPI like :code:`python3 -m pip install pybel[neo4j]` or multiple can
+be installed using a list like :code:`python3 -m pip install pybel[neo4j,indra]`. Likewise, for developer
 installation, extras can be installed in editable mode with :code:`python3 -m pip install -e .[neo4j]` or multiple can
 be installed using a list like :code:`python3 -m pip install -e .[neo4j,indra]`. The available extras are:
 
@@ -50,6 +50,15 @@ package also enables the import of BioPAX, SBML, and SBGN into BEL.
     - :func:`pybel.from_indra_statements`
     - :func:`pybel.from_indra_pickle`
     - :func:`pybel.to_indra`
+
+jupyter
+~~~~~~~
+This extra installs support for visualizing BEL graphs in Jupyter notebooks.
+
+.. seealso:: 
+
+    - :func:`pybel.io.jupyter.to_html`
+    - :func:`pybel.io.jupyter.to_jupyter`
 
 Caveats
 -------


### PR DESCRIPTION
This PR fixes the link to the installation docs in the README. On another note, the reason I was looking at this is that I couldn't get PyBEL to work on Python 3.5.3 (which one of our machines is running), and found that due to a reorganization of the `typing` module, only Python 3.5.4+ will work. It might be good to specify this version limit in the README or the installation instructions.