### PR TITLE
Fix bug in BEP-0008 handling

### DIFF
--- a/src/pybel/parser/parse_bel.py
+++ b/src/pybel/parser/parse_bel.py
@@ -293,14 +293,16 @@ class BELParser(BaseParser):
                 annotation_to_term=annotation_to_term,
                 annotation_to_pattern=annotation_to_pattern,
                 annotation_to_local=annotation_to_local,
+                #
                 citation_clearing=citation_clearing,
                 required_annotations=required_annotations,
             )
 
             self.concept_parser = ConceptParser(
-                allow_naked_names=allow_naked_names,
                 namespace_to_term_to_encoding=namespace_to_term_to_encoding,
                 namespace_to_pattern=namespace_to_pattern,
+                #
+                allow_naked_names=allow_naked_names,
             )
 
         self.control_parser.get_line_number = self.get_line_number
@@ -385,12 +387,15 @@ class BELParser(BaseParser):
             ]) + opt_location,
         )
 
+        self.population = population_tag + nest(concept)
+
         self.single_abundance = MatchFirst([
             self.general_abundance,
             self.gene,
             self.mirna,
             self.protein,
             self.rna,
+            self.population,
         ])
 
         #: `2.1.2 <http://openbel.org/language/version_2.0/bel_specification_version_2.0.html#XcomplexA>`_
@@ -433,9 +438,7 @@ class BELParser(BaseParser):
         #: `2.3.2 <http://openbel.org/language/version_2.0/bel_specification_version_2.0.html#_pathology_path>`_
         self.pathology = pathology_tag + nest(concept)
 
-        self.population = population_tag + nest(concept)
-
-        self.bp_path = self.biological_process | self.pathology | self.population
+        self.bp_path = self.biological_process | self.pathology
         self.bp_path.setParseAction(self.check_function_semantics)
 
         self.activity_standard = activity_tag + nest(

--- a/src/pybel/parser/parse_concept.py
+++ b/src/pybel/parser/parse_concept.py
@@ -36,6 +36,7 @@ class ConceptParser(BaseParser):
         namespace_to_pattern: Optional[Mapping[str, Pattern]] = None,
         default_namespace: Optional[Set[str]] = None,
         allow_naked_names: bool = False,
+        validate: bool = True,
     ) -> None:
         """Initialize the concept parser.
 
@@ -63,23 +64,25 @@ class ConceptParser(BaseParser):
 
             self.namespace_to_name_to_encoding = dict(self.namespace_to_name_to_encoding)
             self.namespace_to_identifier_to_encoding = dict(self.namespace_to_identifier_to_encoding)
-
-            self.identifier_fqualified.setParseAction(self.handle_identifier_qualified)
-            self.identifier_qualified.setParseAction(self.handle_identifier_qualified)
         else:
             self.namespace_to_name_to_encoding = {}
             self.namespace_to_identifier_to_encoding = {}
 
         self.namespace_to_pattern = namespace_to_pattern or {}
+
         self.default_namespace = set(default_namespace) if default_namespace is not None else None
         self.allow_naked_names = allow_naked_names
 
         self.identifier_bare = (word | quote)(NAME)
-        self.identifier_bare.setParseAction(
-            self.handle_namespace_default if self.default_namespace else
-            self.handle_namespace_lenient if self.allow_naked_names else
-            self.handle_namespace_invalid,
-        )
+
+        if validate:
+            self.identifier_fqualified.setParseAction(self.handle_identifier_fqualified)
+            self.identifier_qualified.setParseAction(self.handle_identifier_qualified)
+            self.identifier_bare.setParseAction(
+                self.handle_namespace_default if self.default_namespace else
+                self.handle_namespace_lenient if self.allow_naked_names else
+                self.handle_namespace_invalid,
+            )
 
         super().__init__(
             self.identifier_fqualified | self.identifier_qualified | self.identifier_bare,
@@ -93,49 +96,32 @@ class ConceptParser(BaseParser):
         """Check that the namespace has been defined by a regular expression."""
         return namespace in self.namespace_to_pattern
 
-    def has_namespace(self, namespace: str) -> bool:
-        """Check that the namespace has either been defined by an enumeration or a regular expression."""
-        return self.has_enumerated_namespace(namespace) or self.has_regex_namespace(namespace)
-
-    def has_enumerated_namespace_name(self, namespace: str, name: str) -> bool:
-        """Check that the namespace is defined by an enumeration and that the name is a member."""
-        return self.has_enumerated_namespace(namespace) and name in self.namespace_to_name_to_encoding[namespace]
-
-    def has_regex_namespace_name(self, namespace: str, name: str) -> bool:
-        """Check that the namespace is defined as a regular expression and the name matches it."""
-        return self.has_regex_namespace(namespace) and self.namespace_to_pattern[namespace].match(name)
-
-    def has_namespace_name(self, line: str, position: int, namespace: str, name: str) -> bool:
-        """Check that the namespace is defined and has the given name."""
-        self.raise_for_missing_namespace(line, position, namespace, name)
-        return self.has_enumerated_namespace_name(namespace, name) or self.has_regex_namespace_name(namespace, name)
-
     def raise_for_missing_namespace(self, line: str, position: int, namespace: str, name: str) -> None:
         """Raise an exception if the namespace is not defined."""
-        if not self.has_namespace(namespace):
+        if not self.has_enumerated_namespace(namespace) and not self.has_regex_namespace(namespace):
             raise UndefinedNamespaceWarning(self.get_line_number(), line, position, namespace, name)
 
     def raise_for_missing_name(self, line: str, position: int, namespace: str, name: str) -> None:
         """Raise an exception if the namespace is not defined or if it does not validate the given name."""
         self.raise_for_missing_namespace(line, position, namespace, name)
 
-        if self.has_enumerated_namespace(namespace) and not self.has_enumerated_namespace_name(namespace, name):
+        if self.has_enumerated_namespace(namespace) and name not in self.namespace_to_name_to_encoding[namespace]:
             raise MissingNamespaceNameWarning(self.get_line_number(), line, position, namespace, name)
 
-        if self.has_regex_namespace(namespace) and not self.has_regex_namespace_name(namespace, name):
+        if self.has_regex_namespace(namespace) and not self.namespace_to_pattern[namespace].match(name):
             raise MissingNamespaceRegexWarning(self.get_line_number(), line, position, namespace, name)
 
-    def raise_for_missing_default(self, line: str, position: int, name: str) -> None:
-        """Raise an exception if the name does not belong to the default namespace."""
-        if not self.default_namespace:
-            raise ValueError('Default namespace is not set')
-
-        if name not in self.default_namespace:
-            raise MissingDefaultNameWarning(self.get_line_number(), line, position, name)
+    def handle_identifier_fqualified(self, line: str, position: int, tokens: ParseResults) -> ParseResults:
+        """Handle parsing a qualified OBO-style identifier."""
+        return self._handle_identifier(line, position, tokens, key=IDENTIFIER)
 
     def handle_identifier_qualified(self, line: str, position: int, tokens: ParseResults) -> ParseResults:
         """Handle parsing a qualified identifier."""
-        namespace, name = tokens[NAMESPACE], tokens[NAME]
+        return self._handle_identifier(line, position, tokens, key=NAME)
+
+    def _handle_identifier(self, line: str, position: int, tokens: ParseResults, key) -> ParseResults:
+        """Handle parsing a qualified identifier."""
+        namespace, name = tokens[NAMESPACE], tokens[key]
 
         self.raise_for_missing_namespace(line, position, namespace, name)
         self.raise_for_missing_name(line, position, namespace, name)
@@ -145,7 +131,10 @@ class ConceptParser(BaseParser):
     def handle_namespace_default(self, line: str, position: int, tokens: ParseResults) -> ParseResults:
         """Handle parsing an identifier for the default namespace."""
         name = tokens[NAME]
-        self.raise_for_missing_default(line, position, name)
+        if not self.default_namespace:
+            raise ValueError('Default namespace is not set')
+        if name not in self.default_namespace:
+            raise MissingDefaultNameWarning(self.get_line_number(), line, position, name)
         return tokens
 
     @staticmethod

--- a/src/pybel/parser/parse_concept.py
+++ b/src/pybel/parser/parse_concept.py
@@ -36,7 +36,6 @@ class ConceptParser(BaseParser):
         namespace_to_pattern: Optional[Mapping[str, Pattern]] = None,
         default_namespace: Optional[Set[str]] = None,
         allow_naked_names: bool = False,
-        validate: bool = True,
     ) -> None:
         """Initialize the concept parser.
 
@@ -68,21 +67,19 @@ class ConceptParser(BaseParser):
             self.namespace_to_name_to_encoding = {}
             self.namespace_to_identifier_to_encoding = {}
 
-        self.namespace_to_pattern = namespace_to_pattern or {}
+        self.identifier_fqualified.setParseAction(self.handle_identifier_fqualified)
+        self.identifier_qualified.setParseAction(self.handle_identifier_qualified)
 
+        self.namespace_to_pattern = namespace_to_pattern or {}
         self.default_namespace = set(default_namespace) if default_namespace is not None else None
         self.allow_naked_names = allow_naked_names
 
         self.identifier_bare = (word | quote)(NAME)
-
-        if validate:
-            self.identifier_fqualified.setParseAction(self.handle_identifier_fqualified)
-            self.identifier_qualified.setParseAction(self.handle_identifier_qualified)
-            self.identifier_bare.setParseAction(
-                self.handle_namespace_default if self.default_namespace else
-                self.handle_namespace_lenient if self.allow_naked_names else
-                self.handle_namespace_invalid,
-            )
+        self.identifier_bare.setParseAction(
+            self.handle_namespace_default if self.default_namespace else
+            self.handle_namespace_lenient if self.allow_naked_names else
+            self.handle_namespace_invalid,
+        )
 
         super().__init__(
             self.identifier_fqualified | self.identifier_qualified | self.identifier_bare,

--- a/src/pybel/testing/constants.py
+++ b/src/pybel/testing/constants.py
@@ -48,6 +48,7 @@ test_bel_thorough = os.path.join(bel_dir_path, 'thorough.bel')
 test_bel_isolated = os.path.join(bel_dir_path, 'isolated.bel')
 test_bel_misordered = os.path.join(bel_dir_path, 'misordered.bel')
 test_bel_no_identifier_valiation = os.path.join(bel_dir_path, 'no_identifier_validation_test.bel')
+test_bel_with_obo = os.path.join(bel_dir_path, 'obo.bel')
 
 # JSON Files
 

--- a/src/pybel/testing/resources/bel/obo.bel
+++ b/src/pybel/testing/resources/bel/obo.bel
@@ -1,0 +1,17 @@
+SET DOCUMENT Name = "PyBEL Test Simple"
+SET DOCUMENT Description = "Made for testing PyBEL parsing"
+SET DOCUMENT Version = "1.6.0"
+SET DOCUMENT Copyright = "Copyright (c) Charles Tapley Hoyt. All Rights Reserved."
+SET DOCUMENT Authors = "Charles Tapley Hoyt"
+SET DOCUMENT Licenses = "WTF License"
+SET DOCUMENT ContactInfo = "cthoyt@gmail.com"
+SET DOCUMENT Project = "PyBEL Testing"
+
+# Definition
+DEFINE NAMESPACE hgnc AS PATTERN "\d+"
+
+# Statement
+SET Citation = {"PubMed", "123456"}
+SET Evidence = "Test Evidence"
+
+p(hgnc:391 ! AKT1) -> p(hgnc:3236 ! EGFR)

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -3,6 +3,7 @@
 """Constants for PyBEL tests."""
 
 import logging
+import re
 import unittest
 from json import dumps
 
@@ -169,6 +170,20 @@ class TestTokenParserBase(unittest.TestCase):
             cls.graph,
             autostreamline=False,
             disallow_unqualified_translocations=True,
+            namespace_to_pattern={
+                'HGNC': re.compile(r'.*'),
+                'SNP': re.compile(r'.*'),
+                'CHEBI': re.compile(r'.*'),
+                'REF': re.compile(r'.*'),
+                'MOD': re.compile(r'.*'),
+                'EFO': re.compile(r'.*'),
+                'GO': re.compile(r'.*'),
+                'UBERON': re.compile(r'.*'),
+                'FPLX': re.compile(r'.*'),
+                'MESH': re.compile(r'.*'),
+                'MGI': re.compile(r'.*'),
+                'dbSNP': re.compile(r'.*'),
+            }
         )
 
     def setUp(self):

--- a/tests/test_parse/test_parse_bel_relations.py
+++ b/tests/test_parse/test_parse_bel_relations.py
@@ -65,14 +65,14 @@ class TestRelations(TestTokenParserBase):
 
     def test_singleton(self):
         """Test singleton composite in subject."""
-        statement = 'composite(p(HGNC:CASP8),p(HGNC:FADD),a(ADO:"Abeta_42"))'
+        statement = 'composite(p(HGNC:CASP8),p(HGNC:FADD),a(CHEBI:"Abeta_42"))'
         result = self.parser.statement.parseString(statement)
 
         expected = [
             COMPOSITE,
             [PROTEIN, ['HGNC', 'CASP8']],
             [PROTEIN, ['HGNC', 'FADD']],
-            [ABUNDANCE, ['ADO', 'Abeta_42']]
+            [ABUNDANCE, ['CHEBI', 'Abeta_42']]
         ]
         self.assertEqual(expected, result.asList())
 
@@ -82,7 +82,7 @@ class TestRelations(TestTokenParserBase):
         sub_member_2 = protein('HGNC', 'FADD')
         self.assert_has_node(sub_member_2)
 
-        sub_member_3 = abundance('ADO', 'Abeta_42')
+        sub_member_3 = abundance('CHEBI', 'Abeta_42')
         self.assert_has_node(sub_member_3)
 
         sub = composite_abundance([sub_member_1, sub_member_2, sub_member_3])
@@ -93,7 +93,7 @@ class TestRelations(TestTokenParserBase):
 
     def test_predicate_failure(self):
         """Checks that if there's a problem with the relation/object, that an error gets thrown"""
-        statement = 'composite(p(HGNC:CASP8),p(HGNC:FADD),a(ADO:"Abeta_42")) -> nope(GO:"neuron apoptotic process")'
+        statement = 'composite(p(HGNC:CASP8),p(HGNC:FADD),a(CHEBI:"Abeta_42")) -> nope(GO:"neuron apoptotic process")'
 
         with self.assertRaises(ParseException):
             self.parser.relation.parseString(statement)
@@ -102,12 +102,12 @@ class TestRelations(TestTokenParserBase):
         """Test composite in subject. See BEL 2.0 specification
         `3.1.1 <http://openbel.org/language/web/version_2.0/bel_specification_version_2.0.html#Xincreases>`_
         """
-        statement = 'composite(p(HGNC:CASP8),p(HGNC:FADD),a(ADO:"Abeta_42")) -> bp(GO:"neuron apoptotic process")'
+        statement = 'composite(p(HGNC:CASP8),p(HGNC:FADD),a(CHEBI:"Abeta_42")) -> bp(GO:"neuron apoptotic process")'
         result = self.parser.relation.parseString(statement)
 
         expected = [
             [COMPOSITE, [PROTEIN, ['HGNC', 'CASP8']], [PROTEIN, ['HGNC', 'FADD']],
-             [ABUNDANCE, ['ADO', 'Abeta_42']]],
+             [ABUNDANCE, ['CHEBI', 'Abeta_42']]],
             INCREASES,
             [BIOPROCESS, ['GO', 'neuron apoptotic process']]
         ]
@@ -119,7 +119,7 @@ class TestRelations(TestTokenParserBase):
         sub_member_2 = protein('HGNC', 'FADD')
         self.assert_has_node(sub_member_2)
 
-        sub_member_3 = abundance('ADO', 'Abeta_42')
+        sub_member_3 = abundance('CHEBI', 'Abeta_42')
         self.assert_has_node(sub_member_3)
 
         sub = composite_abundance([sub_member_1, sub_member_2, sub_member_3])
@@ -175,7 +175,7 @@ class TestRelations(TestTokenParserBase):
         """Test translocation in object. See BEL 2.0 specification
         `3.1.2 <http://openbel.org/language/web/version_2.0/bel_specification_version_2.0.html#XdIncreases>`_
         """
-        statement = 'a(ADO:"Abeta_42") => tloc(a(CHEBI:"calcium(2+)"),fromLoc(MESH:"Cell Membrane"),' \
+        statement = 'a(CHEBI:"Abeta_42") => tloc(a(CHEBI:"calcium(2+)"),fromLoc(MESH:"Cell Membrane"),' \
                     'toLoc(MESH:"Intracellular Space"))'
         result = self.parser.relation.parseString(statement)
 
@@ -183,7 +183,7 @@ class TestRelations(TestTokenParserBase):
             SUBJECT: {
                 FUNCTION: ABUNDANCE,
                 CONCEPT: {
-                    NAMESPACE: 'ADO',
+                    NAMESPACE: 'CHEBI',
                     NAME: 'Abeta_42',
                 },
             },
@@ -205,7 +205,7 @@ class TestRelations(TestTokenParserBase):
         }
         self.assertEqual(expected_dict, result.asDict())
 
-        sub = abundance('ADO', 'Abeta_42')
+        sub = abundance('CHEBI', 'Abeta_42')
         self.assert_has_node(sub)
 
         obj = abundance('CHEBI', 'calcium(2+)')
@@ -229,7 +229,7 @@ class TestRelations(TestTokenParserBase):
 
         3.1.3 http://openbel.org/language/web/version_2.0/bel_specification_version_2.0.html#Xdecreases
         """
-        statement = 'pep(p(SFAM:"CAPN Family", location(GO:intracellular))) -| reaction(reactants(p(HGNC:CDK5R1)),products(p(HGNC:CDK5)))'
+        statement = 'pep(p(FPLX:CAPN, location(GO:intracellular))) -| reaction(reactants(p(HGNC:CDK5R1)),products(p(HGNC:CDK5)))'
         result = self.parser.relation.parseString(statement)
 
         expected_dict = {
@@ -238,8 +238,8 @@ class TestRelations(TestTokenParserBase):
                 TARGET: {
                     FUNCTION: PROTEIN,
                     CONCEPT: {
-                        NAMESPACE: 'SFAM',
-                        NAME: 'CAPN Family',
+                        NAMESPACE: 'FPLX',
+                        NAME: 'CAPN',
                     },
                     LOCATION: {NAMESPACE: 'GO', NAME: 'intracellular'}
                 },
@@ -273,7 +273,7 @@ class TestRelations(TestTokenParserBase):
         }
         self.assertEqual(expected_dict, result.asDict())
 
-        sub = protein('SFAM', 'CAPN Family')
+        sub = protein('FPLX', 'CAPN')
         self.assert_has_node(sub)
 
         obj_member_1 = protein('HGNC', 'CDK5R1')
@@ -454,7 +454,7 @@ class TestRelations(TestTokenParserBase):
 
         See also: 3.1.6 http://openbel.org/language/web/version_2.0/bel_specification_version_2.0.html#Xcnc
         """
-        statement = 'g(HGNC:APP,sub(G,275341,C)) cnc path(MESHD:"Alzheimer Disease")'
+        statement = 'g(HGNC:APP,sub(G,275341,C)) cnc path(MESH:"Alzheimer Disease")'
         result = self.parser.relation.parseString(statement)
 
         expected_dict = {
@@ -475,7 +475,7 @@ class TestRelations(TestTokenParserBase):
             OBJECT: {
                 FUNCTION: PATHOLOGY,
                 CONCEPT: {
-                    NAMESPACE: 'MESHD',
+                    NAMESPACE: 'MESH',
                     NAME: 'Alzheimer Disease',
                 },
             },
@@ -487,7 +487,7 @@ class TestRelations(TestTokenParserBase):
         sub = app_gene.with_variants(hgvs('c.275341G>C'))
         self.assert_has_node(sub)
 
-        obj = Pathology('MESHD', 'Alzheimer Disease')
+        obj = Pathology('MESH', 'Alzheimer Disease')
         self.assert_has_node(obj)
 
         self.assert_has_edge(sub, obj, relation=expected_dict[RELATION])
@@ -581,7 +581,7 @@ class TestRelations(TestTokenParserBase):
         """
         3.2.1 http://openbel.org/language/web/version_2.0/bel_specification_version_2.0.html#XnegCor
         Test phosphoralation tag"""
-        statement = 'kin(p(SFAM:"GSK3 Family")) neg p(HGNC:MAPT,pmod(P))'
+        statement = 'kin(p(FPLX:GSK3)) neg p(HGNC:MAPT,pmod(P))'
         result = self.parser.relation.parseString(statement)
 
         expected_dict = {
@@ -594,8 +594,8 @@ class TestRelations(TestTokenParserBase):
                 TARGET: {
                     FUNCTION: PROTEIN,
                     CONCEPT: {
-                        NAMESPACE: 'SFAM',
-                        NAME: 'GSK3 Family',
+                        NAMESPACE: 'FPLX',
+                        NAME: 'GSK3',
                     },
                 },
             },
@@ -611,7 +611,7 @@ class TestRelations(TestTokenParserBase):
         }
         self.assertEqual(expected_dict, result.asDict())
 
-        sub = protein('SFAM', 'GSK3 Family')
+        sub = protein('FPLX', 'GSK3')
         self.assert_has_node(sub)
 
         obj = protein('HGNC', 'MAPT', variants=pmod('Ph'))
@@ -758,11 +758,11 @@ class TestRelations(TestTokenParserBase):
         self.assertEqual('r(HGNC:AKT1, loc(GO:intracellular)) translatedTo p(HGNC:AKT1)', calculated_edge_bel)
 
     def test_component_list(self):
-        s = 'complex(SCOMP:"C1 Complex") hasComponents list(p(HGNC:C1QB), p(HGNC:C1S))'
+        s = 'complex(FPLX:C1) hasComponents list(p(HGNC:C1QB), p(HGNC:C1S))'
         result = self.parser.relation.parseString(s)
 
         expected_result_list = [
-            [COMPLEX, ['SCOMP', 'C1 Complex']],
+            [COMPLEX, ['FPLX', 'C1']],
             'hasComponents',
             [
                 [PROTEIN, ['HGNC', 'C1QB']],
@@ -771,7 +771,7 @@ class TestRelations(TestTokenParserBase):
         ]
         self.assertEqual(expected_result_list, result.asList())
 
-        sub = named_complex_abundance('SCOMP', 'C1 Complex')
+        sub = named_complex_abundance('FPLX', 'C1')
         self.assert_has_node(sub)
         child_1 = hgnc('C1QB')
         self.assert_has_node(child_1)
@@ -784,10 +784,10 @@ class TestRelations(TestTokenParserBase):
         """
         3.4.2 http://openbel.org/language/web/version_2.0/bel_specification_version_2.0.html#_hasmembers
         """
-        statement = 'p(PKC:a) hasMembers list(p(HGNC:PRKCA), p(HGNC:PRKCB), p(HGNC:PRKCD), p(HGNC:PRKCE))'
+        statement = 'p(FPLX:PKC) hasMembers list(p(HGNC:PRKCA), p(HGNC:PRKCB), p(HGNC:PRKCD), p(HGNC:PRKCE))'
         result = self.parser.relation.parseString(statement)
         expected_result = [
-            [PROTEIN, ['PKC', 'a']],
+            [PROTEIN, ['FPLX', 'PKC']],
             'hasMembers',
             [
                 [PROTEIN, ['HGNC', 'PRKCA']],
@@ -798,7 +798,7 @@ class TestRelations(TestTokenParserBase):
         ]
         self.assertEqual(expected_result, result.asList())
 
-        sub = protein('PKC', 'a')
+        sub = protein('FPLX', 'PKC')
         obj_1 = protein('HGNC', 'PRKCA')
         obj_2 = protein('HGNC', 'PRKCB')
         obj_3 = protein('HGNC', 'PRKCD')

--- a/tests/test_parse/test_parse_bel_variants.py
+++ b/tests/test_parse/test_parse_bel_variants.py
@@ -3,6 +3,7 @@
 """Test parsing variants."""
 
 import logging
+import re
 import unittest
 
 from pybel.constants import (
@@ -95,7 +96,10 @@ class TestHGVSParser(unittest.TestCase):
 
 class TestPmod(unittest.TestCase):
     def setUp(self):
-        identifier_parser = ConceptParser()
+        identifier_parser = ConceptParser(namespace_to_pattern={
+            'MOD': re.compile('.*'),
+            'HGNC': re.compile('.*'),
+        })
         identifier_qualified = identifier_parser.identifier_qualified
         self.parser = get_protein_modification_language(identifier_qualified)
 
@@ -117,15 +121,11 @@ class TestPmod(unittest.TestCase):
         self._help_test_pmod_simple('proteinModification(P)')
         # long function, new modification
         self._help_test_pmod_simple('proteinModification(Ph)')
-        # long function, qualified modification
-        self._help_test_pmod_simple('proteinModification(bel:Ph)')
 
         # short function, legacy modification
         self._help_test_pmod_simple('pmod(P)')
         # short function, new modification
         self._help_test_pmod_simple('pmod(Ph)')
-        # short function, qualified modification
-        self._help_test_pmod_simple('pmod(bel:Ph)')
 
     def _help_test_pmod_with_residue(self, statement):
         result = self.parser.parseString(statement)
@@ -168,14 +168,10 @@ class TestPmod(unittest.TestCase):
         self._help_test_pmod_full('proteinModification(P, S, 473)')
         self._help_test_pmod_full('proteinModification(Ph, Ser, 473)')
         self._help_test_pmod_full('proteinModification(Ph, S, 473)')
-        self._help_test_pmod_full('proteinModification(bel:Ph, Ser, 473)')
-        self._help_test_pmod_full('proteinModification(bel:Ph, S, 473)')
         self._help_test_pmod_full('pmod(P, Ser, 473)')
         self._help_test_pmod_full('pmod(P, S, 473)')
         self._help_test_pmod_full('pmod(Ph, Ser, 473)')
         self._help_test_pmod_full('pmod(Ph, S, 473)')
-        self._help_test_pmod_full('pmod(bel:Ph, Ser, 473)')
-        self._help_test_pmod_full('pmod(bel:Ph, S, 473)')
 
     def _help_test_non_standard_namespace(self, statement):
         result = self.parser.parseString(statement)
@@ -372,7 +368,7 @@ class TestTruncationParser(unittest.TestCase):
 
 class TestFusionParser(unittest.TestCase):
     def setUp(self):
-        identifier_parser = ConceptParser()
+        identifier_parser = ConceptParser(namespace_to_pattern={'HGNC': re.compile('.*')})
         identifier_qualified = identifier_parser.identifier_qualified
         self.parser = get_fusion_language(identifier_qualified)
 
@@ -505,7 +501,7 @@ class TestFusionParser(unittest.TestCase):
 
 class TestLocation(unittest.TestCase):
     def setUp(self):
-        identifier_parser = ConceptParser()
+        identifier_parser = ConceptParser(namespace_to_pattern={'GO': re.compile('.*')})
         identifier_qualified = identifier_parser.identifier_qualified
         self.parser = get_location_language(identifier_qualified)
 


### PR DESCRIPTION
- Also required explicitly enumerating namespaces used in tests with dummpy regex
- Removed bel: reference for default namespace from tests. This is no longer supported
- Upgraded some old namespaces from examples (no more SFAM, SCOMP, ADO)
- Make sure pop() works in translocations