### PR TITLE
Add importer from Fraunhofer's OrientDB

### DIFF
--- a/docs/source/reference/io.rst
+++ b/docs/source/reference/io.rst
@@ -199,6 +199,12 @@ BioDati
 .. autofunction:: pybel.to_biodati
 .. autofunction:: pybel.from_biodati
 
+Fraunhofer OrientDB
+~~~~~~~~~~~~~~~~~~~
+.. automodule:: pybel.io.fraunhofer_orientdb
+
+.. autofunction:: pybel.from_fraunhofer_orientdb
+
 Databases
 ---------
 SQL Databases

--- a/src/pybel/__init__.py
+++ b/src/pybel/__init__.py
@@ -6,17 +6,17 @@ from .canonicalize import edge_to_bel, to_bel_script, to_bel_script_gz, to_bel_s
 from .dsl import BaseAbundance, BaseEntity
 from .io import (
     dump, from_bel_commons, from_bel_script, from_bel_script_url, from_biodati, from_biopax, from_bytes, from_cbn_jgif,
-    from_cbn_jgif_file, from_cx, from_cx_file, from_cx_gz, from_cx_jsons, from_graphdati, from_graphdati_file,
-    from_graphdati_gz, from_graphdati_jsons, from_hetionet_file, from_hetionet_gz, from_hetionet_json,
-    from_hipathia_dfs, from_hipathia_paths, from_indra_pickle, from_indra_statements, from_indra_statements_json,
-    from_indra_statements_json_file, from_jgif, from_jgif_file, from_jgif_gz, from_jgif_jsons, from_nodelink,
-    from_nodelink_file, from_nodelink_gz, from_nodelink_jsons, from_pickle, get_hetionet, load, post_jgif,
-    to_bel_commons, to_biodati, to_bytes, to_csv, to_cx, to_cx_file, to_cx_gz, to_cx_jsons, to_edgelist, to_graphdati,
-    to_graphdati_file, to_graphdati_gz, to_graphdati_jsonl, to_graphdati_jsonl_gz, to_graphdati_jsons, to_graphml,
-    to_gsea, to_hipathia, to_hipathia_dfs, to_indra_statements, to_indra_statements_json, to_indra_statements_json_file,
-    to_jgif, to_jgif_file, to_jgif_gz, to_jgif_jsons, to_neo4j, to_nodelink, to_nodelink_file, to_nodelink_gz,
-    to_nodelink_jsons, to_npa_dfs, to_npa_directory, to_pickle, to_sif, to_tsv, to_umbrella_nodelink,
-    to_umbrella_nodelink_file, to_umbrella_nodelink_gz,
+    from_cbn_jgif_file, from_cx, from_cx_file, from_cx_gz, from_cx_jsons, from_fraunhofer_orientdb, from_graphdati,
+    from_graphdati_file, from_graphdati_gz, from_graphdati_jsons, from_hetionet_file, from_hetionet_gz,
+    from_hetionet_json, from_hipathia_dfs, from_hipathia_paths, from_indra_pickle, from_indra_statements,
+    from_indra_statements_json, from_indra_statements_json_file, from_jgif, from_jgif_file, from_jgif_gz,
+    from_jgif_jsons, from_nodelink, from_nodelink_file, from_nodelink_gz, from_nodelink_jsons, from_pickle,
+    get_hetionet, load, post_jgif, to_bel_commons, to_biodati, to_bytes, to_csv, to_cx, to_cx_file, to_cx_gz,
+    to_cx_jsons, to_edgelist, to_graphdati, to_graphdati_file, to_graphdati_gz, to_graphdati_jsonl,
+    to_graphdati_jsonl_gz, to_graphdati_jsons, to_graphml, to_gsea, to_hipathia, to_hipathia_dfs, to_indra_statements,
+    to_indra_statements_json, to_indra_statements_json_file, to_jgif, to_jgif_file, to_jgif_gz, to_jgif_jsons, to_neo4j,
+    to_nodelink, to_nodelink_file, to_nodelink_gz, to_nodelink_jsons, to_npa_dfs, to_npa_directory, to_pickle, to_sif,
+    to_tsv, to_umbrella_nodelink, to_umbrella_nodelink_file, to_umbrella_nodelink_gz,
 )
 from .manager import Manager, from_database, to_database
 from .struct import BELGraph, Pipeline, Query

--- a/src/pybel/io/__init__.py
+++ b/src/pybel/io/__init__.py
@@ -12,6 +12,7 @@ from .bel_commons_client import from_bel_commons, to_bel_commons
 from .biodati_client import from_biodati, to_biodati
 from .cx import from_cx, from_cx_file, from_cx_gz, from_cx_jsons, to_cx, to_cx_file, to_cx_gz, to_cx_jsons
 from .extras import to_csv, to_gsea, to_sif
+from .fraunhofer_orientdb import from_fraunhofer_orientdb
 from .gpickle import from_bytes, from_pickle, to_bytes, to_pickle
 from .graphdati import (
     from_graphdati, from_graphdati_file, from_graphdati_gz, from_graphdati_jsons, to_graphdati, to_graphdati_file,

--- a/src/pybel/io/fraunhofer_orientdb.py
+++ b/src/pybel/io/fraunhofer_orientdb.py
@@ -134,7 +134,7 @@ def _request_graphstore(
     if count_query is None:
         count_query = 'select count(@rid) from E'
     count_query = quote_plus(count_query)
-    count_url = f'{base}/{database}/sql/{count_query}'
+    count_url = '{base}/{database}/sql/{count_query}'.format(base=base, database=database, count_query=count_query)
     count_res = requests.get(count_url, auth=(user, password))
     count = count_res.json()['result'][0]['count']
     logging.debug('fraunhofer orientdb has %d edges', count)
@@ -147,7 +147,9 @@ def _request_graphstore(
         select_query = select_query_template.format(limit=page_size, offset=offset * page_size)
         logger.debug('query: %s', select_query)
         select_query = quote_plus(select_query)
-        select_url = f'{base}/{database}/sql/{select_query}/{page_size}/*:1'
+        select_url = '{base}/{database}/sql/{select_query}/{page_size}/*:1'.format(
+            base=base, database=database, select_query=select_query, page_size=page_size,
+        )
         res = requests.get(select_url, auth=(user, password))
         res_json = res.json()
         result = res_json['result']

--- a/src/pybel/io/fraunhofer_orientdb.py
+++ b/src/pybel/io/fraunhofer_orientdb.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+
+"""Transport functions for `Franhofer SCAI's OrientDB <http://graphstore.scai.fraunhofer.de>`_.
+
+Fraunhofer SCAI hosts an OrientDB instance that contains BEL in a schema similar to Umbrella
+Node-Link. However, they include custom relations that do not come from a controlled vocabulary,
+and have not made the schema, ETL scripts, or documentation available.
+
+Unlike BioDati and BEL Commons, the Fraunhofer OrientDB does not allow for uploads, so only
+a single function :func:`from_fraunhofer_orientdb` is provided by PyBEL.
+"""
+
+import logging
+from typing import Any, List, Mapping, Optional
+
+import requests
+
+from pybel.parser import BELParser
+from pybel.struct import BELGraph
+
+__all__ = [
+    'from_fraunhofer_orientdb',
+]
+
+logger = logging.getLogger(__name__)
+
+
+def from_fraunhofer_orientdb(  # noqa:S107
+    database: str = 'covid',
+    user: str = 'covid_user',
+    password: str = 'covid',
+    query: Optional[str] = None
+) -> BELGraph:
+    """Get a BEL graph.
+
+    :param database: The OrientDB database to connect to
+    :param user: The user to connect to OrientDB
+    :param password: The password to connect to OrientDB
+    :param query: The query to run. Defaults to the URL encoded version of ``select from E``,
+     where ``E`` is all edges in the OrientDB edge database. Likely does not need to be changed,
+     except in the case of selecting specific subsets of edges. Make sure you URL encode it
+     properly, because OrientDB's RESTful API puts it in the URL's path.
+    """
+    graph = BELGraph()
+    parser = BELParser(graph, skip_validation=True)
+
+    # FIXME this does not page through results, so it only
+    #  gets the first set of 20 or so. Needs updating
+
+    results = _request_graphstore(database, user, password, query=query)
+    for result in results:
+        _parse_result(parser, result)
+    return graph
+
+
+def _parse_result(parser: BELParser, result: Mapping[str, Any]) -> None:
+    parser.control_parser.clear()
+    parser.control_parser.citation_db = 'PubMed'
+    parser.control_parser.citation_db_id = result['pmid']
+    parser.control_parser.evidence = result['evidence']
+    parser.control_parser.annotations.update(result['annotation'])
+
+    source = result['in']['bel']
+    relation = result['@class']
+    target = result['out']['bel']
+    statement = ' '.join([source, relation, target])
+    parser.parseString(statement)
+
+
+def _request_graphstore(
+    database: str,
+    user: str,
+    password: str,
+    query: Optional[str] = None,
+    limit='5',
+) -> List[Mapping[str, Any]]:
+    if query is None:
+        query = 'select%20from%20E'
+    url = 'http://graphstore.scai.fraunhofer.de/query/{}/sql/{}/{}/*:1'.format(database, query, limit)
+    res = requests.get(url, auth=(user, password))
+    res_json = res.json()
+    for k, v in res_json.items():
+        if k != 'result':
+            logger.debug('%s: %s', k, v)
+    return res_json['result']
+
+
+def _main():
+    graph = from_fraunhofer_orientdb()
+    print('NODES\n')
+    for node in graph:
+        print(node)
+
+    print('\n\nEDGES\n')
+    for u, v, d in graph.edges(data=True):
+        print(graph.edge_to_bel(u, v, d))
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    _main()

--- a/src/pybel/io/fraunhofer_orientdb.py
+++ b/src/pybel/io/fraunhofer_orientdb.py
@@ -31,7 +31,7 @@ def from_fraunhofer_orientdb(  # noqa:S107
     password: str = 'covid',
     query: Optional[str] = None
 ) -> BELGraph:
-    """Get a BEL graph.
+    """Get a BEL graph from the Fraunhofer SCAI OrientDB.
 
     :param database: The OrientDB database to connect to
     :param user: The user to connect to OrientDB
@@ -40,6 +40,21 @@ def from_fraunhofer_orientdb(  # noqa:S107
      where ``E`` is all edges in the OrientDB edge database. Likely does not need to be changed,
      except in the case of selecting specific subsets of edges. Make sure you URL encode it
      properly, because OrientDB's RESTful API puts it in the URL's path.
+
+    By default, this function connects to the ``covid`` database, that corresponds to the
+    COVID-19 Knowledge Graph [0]_. If other databases in the Fraunhofer SCAI OrientDB are
+    published and demo username/password combinations are given, the following table will
+    be updated.
+
+    +----------+------------+----------+
+    | Database | Username   | Password |
+    +==========+============+==========+
+    | covid    | covid_user | covid    |
+    +----------+------------+----------+
+
+    .. [0] Domingo-Fernández, D., *et al.* (2020). `COVID-19 Knowledge Graph: a computable, multi-modal,
+           cause-and-effect knowledge model of COVID-19 pathophysiology
+           <https://doi.org/10.1101/2020.04.14.040667>`_. *bioRxiv* 2020.04.14.040667.
     """
     graph = BELGraph()
     parser = BELParser(graph, skip_validation=True)

--- a/src/pybel/io/fraunhofer_orientdb.py
+++ b/src/pybel/io/fraunhofer_orientdb.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 
-"""Transport functions for `Franhofer SCAI's OrientDB <http://graphstore.scai.fraunhofer.de>`_.
+"""Transport functions for `Franhofer's OrientDB <http://graphstore.scai.fraunhofer.de>`_.
 
-Fraunhofer SCAI hosts an OrientDB instance that contains BEL in a schema similar to Umbrella
-Node-Link. However, they include custom relations that do not come from a controlled vocabulary,
-and have not made the schema, ETL scripts, or documentation available.
+`Fraunhofer <https://www.scai.fraunhofer.de/en/business-research-areas/bioinformatics.html>`_ hosts
+an instance of `OrientDB <https://orientdb.com/>`_ that contains BEL in a schema similar to
+:mod:`pybel.io.umbrella_nodelink`. However, they include custom relations that do not come
+from a controlled vocabulary, and have not made the schema, ETL scripts, or documentation available.
 
 Unlike BioDati and BEL Commons, the Fraunhofer OrientDB does not allow for uploads, so only
-a single function :func:`from_fraunhofer_orientdb` is provided by PyBEL.
+a single function :func:`pybel.from_fraunhofer_orientdb` is provided by PyBEL.
 """
 
 import logging
@@ -34,7 +35,7 @@ def from_fraunhofer_orientdb(  # noqa:S107
     password: str = 'covid',
     query: Optional[str] = None
 ) -> BELGraph:
-    """Get a BEL graph from the Fraunhofer SCAI OrientDB.
+    """Get a BEL graph from the Fraunhofer OrientDB.
 
     :param database: The OrientDB database to connect to
     :param user: The user to connect to OrientDB
@@ -45,7 +46,7 @@ def from_fraunhofer_orientdb(  # noqa:S107
      properly, because OrientDB's RESTful API puts it in the URL's path.
 
     By default, this function connects to the ``covid`` database, that corresponds to the
-    COVID-19 Knowledge Graph [0]_. If other databases in the Fraunhofer SCAI OrientDB are
+    COVID-19 Knowledge Graph [0]_. If other databases in the Fraunhofer OrientDB are
     published and demo username/password combinations are given, the following table will
     be updated.
 
@@ -54,11 +55,6 @@ def from_fraunhofer_orientdb(  # noqa:S107
     +==========+============+==========+
     | covid    | covid_user | covid    |
     +----------+------------+----------+
-
-    .. [0] Domingo-Fernández, D., *et al.* (2020). `COVID-19 Knowledge Graph: a computable, multi-modal,
-           cause-and-effect knowledge model of COVID-19 pathophysiology
-           <https://doi.org/10.1101/2020.04.14.040667>`_. *bioRxiv* 2020.04.14.040667.
-
 
     The COVID graph can be downloaded like this:
 
@@ -71,6 +67,17 @@ def from_fraunhofer_orientdb(  # noqa:S107
             password='covid',
         )
         graph.summarize()
+
+    .. warning::
+
+        It was initially planned to handle some of the non-standard relationships listed in the
+        Fraunhofer OrientDB's `schema <http://graphstore.scai.fraunhofer.de/studio/index.html#/database/covid/schema>`_
+        in their OrientDB Studio instance, but none of them actually appear in the only network that is accessible.
+        If this changes, please leave an issue at https://github.com/pybel/pybel/issues so it can be addressed.
+
+    .. [0] Domingo-Fernández, D., *et al.* (2020). `COVID-19 Knowledge Graph: a computable, multi-modal,
+           cause-and-effect knowledge model of COVID-19 pathophysiology
+           <https://doi.org/10.1101/2020.04.14.040667>`_. *bioRxiv* 2020.04.14.040667.
     """
     graph = BELGraph(name='Fraunhofer OrientDB: {}'.format(database))
     parser = BELParser(graph, skip_validation=True)


### PR DESCRIPTION
- [x] Initial implementation of edge record to BEL
- [x] Pagination through OrientDB's results (not specific to this database; 35908acd)

## Errors in Database

It appears that the ordering of `loc()` and `pmod()` is not respected

```
WARNING:pybel.io.fraunhofer_orientdb:could not parse p(MESH:"Spike Glycoprotein, Coronavirus",loc(GOCC:"endoplasmic reticulum"),pmod(Glyco)) regulates p(HGNC:"CANX")
```

It appears that complexes, composites, and family relations have been loaded backwards:

```
WARNING:pybel.io.fraunhofer_orientdb:could not parse list(p(REFSEQ:"YP_009725298.1"),p(REFSEQ:"YP_009725299.1"),p(REFSEQ:"YP_009725302.1")) hasMembers complex(GO:"viral replication complex")
WARNING:pybel.io.fraunhofer_orientdb:could not parse list(p(FIXME:"s1"),p(FIXME:"s2")) hasMembers p(NCBIGENE:"43740568")
WARNING:pybel.io.fraunhofer_orientdb:could not parse list(p(FIXME:"nsp12"),p(FIXME:"nsp13"),p(FIXME:"nsp14"),p(FIXME:"nsp15"),p(FIXME:"nsp16"),p(FIXME:"nsp5"),p(REFSEQ:"YP_009725299.1"),p(REFSEQ:"YP_009725303.1"),p(REFSEQ:"YP_009725304.1"),p(REFSEQ:"YP_009725306.1")) hasMembers complex(GO:"viral replication complex")
```


## Future

Initially it was planned to handle some of the non-standard relationships that can be found in http://graphstore.scai.fraunhofer.de/studio/index.html#/database/covid/schema, but none of them actually appear in the `covid` database. Can come back to this later if anyone ever feels like it's important.



