### PR TITLE
Update insertions

### DIFF
--- a/src/pybel/canonicalize.py
+++ b/src/pybel/canonicalize.py
@@ -14,10 +14,9 @@ from networkx.utils import open_file
 import bel_resources.constants
 from bel_resources import make_knowledge_header
 from .constants import (
-    ACTIVITY, ANNOTATIONS, BEL_DEFAULT_NAMESPACE, CELL_SURFACE, CITATION, CITATION_TYPE_PUBMED, DEGRADATION, EFFECT,
-    EVIDENCE, EXTRACELLULAR, FROM_LOC, INTRACELLULAR, LOCATION, MODIFIER, NAME, NAMESPACE, PYBEL_AUTOEVIDENCE,
-    PYBEL_PUBMED, RELATION, SET_CITATION_FMT, SOURCE_MODIFIER, TARGET_MODIFIER, TO_LOC, TRANSLOCATION,
-    UNQUALIFIED_EDGES, VARIANTS,
+    ACTIVITY, ANNOTATIONS, CITATION, CITATION_TYPE_PUBMED, DEGRADATION, EFFECT, EVIDENCE, FROM_LOC, LOCATION, MODIFIER,
+    NAME, NAMESPACE, PYBEL_AUTOEVIDENCE, PYBEL_PUBMED, RELATION, SET_CITATION_FMT, SOURCE_MODIFIER, TARGET_MODIFIER,
+    TO_LOC, TRANSLOCATION, UNQUALIFIED_EDGES, VARIANTS,
 )
 from .dsl import BaseAbundance, BaseEntity, FusionBase, ListAbundance, Reaction
 from .language import Entity
@@ -136,16 +135,6 @@ def _decanonicalize_edge_node(
 
         to_loc_data: Entity = effect[TO_LOC]
         from_loc_data: Entity = effect[FROM_LOC]
-
-        if from_loc_data[NAMESPACE] == BEL_DEFAULT_NAMESPACE and from_loc_data[NAME] == INTRACELLULAR:
-            if to_loc_data[NAMESPACE] == BEL_DEFAULT_NAMESPACE and to_loc_data[NAME] == EXTRACELLULAR:
-                warnings.warn('deprecated output of BEL default namespace', DeprecationWarning)
-                return f'sec({node_str})'
-            if to_loc_data[NAMESPACE] == BEL_DEFAULT_NAMESPACE and to_loc_data[NAME] == CELL_SURFACE:
-                warnings.warn('deprecated output of BEL default namespace', DeprecationWarning)
-                return f'surf({node_str})'
-            raise ValueError
-
         return f"tloc({node_str}, fromLoc({from_loc_data}), toLoc({to_loc_data}))"
 
     raise ValueError('invalid modifier: {}'.format(modifier))

--- a/src/pybel/constants.py
+++ b/src/pybel/constants.py
@@ -23,9 +23,6 @@ def get_cache_connection() -> str:
 PYBEL_CONTEXT_TAG = 'pybel_context'
 PYBEL_AUTOEVIDENCE = 'Automatically added by PyBEL'
 
-#: The default namespace given to entities in the BEL language
-BEL_DEFAULT_NAMESPACE = 'bel'
-
 CITATION_TYPE_BOOK = 'Book'
 CITATION_TYPE_PUBMED = 'PubMed'
 CITATION_TYPE_PMC = 'PubMed Central'

--- a/src/pybel/dsl/edges.py
+++ b/src/pybel/dsl/edges.py
@@ -6,7 +6,7 @@ import warnings
 from typing import Dict, Optional, Union
 
 from ..constants import (
-    ACTIVITY, BEL_DEFAULT_NAMESPACE, CELL_SURFACE, DEGRADATION, EFFECT, EXTRACELLULAR, FROM_LOC, INTRACELLULAR,
+    ACTIVITY, CELL_SURFACE, DEGRADATION, EFFECT, EXTRACELLULAR, FROM_LOC, INTRACELLULAR,
     LOCATION, MODIFIER, NAME, NAMESPACE, TO_LOC, TRANSLOCATION,
 )
 from ..language import Entity, activity_mapping, compartment_mapping
@@ -58,7 +58,7 @@ def activity(
     """
     rv = _modifier_helper(ACTIVITY, location=location)
 
-    if namespace == BEL_DEFAULT_NAMESPACE or (name and not namespace):
+    if name and not namespace:
         rv[EFFECT] = activity_mapping[name]
     elif not name and not namespace and not identifier:
         pass
@@ -92,16 +92,10 @@ def translocation(
     rv = _modifier_helper(TRANSLOCATION)
     if isinstance(from_loc, str):
         from_loc = compartment_mapping[from_loc]
-    elif from_loc[NAMESPACE] == BEL_DEFAULT_NAMESPACE:
-        warnings.warn('Deprecated usage of translocation()')
-        from_loc = compartment_mapping[from_loc[NAME]]
     if not isinstance(from_loc, Entity):
         raise TypeError
     if isinstance(to_loc, str):
         to_loc = compartment_mapping[to_loc]
-    elif to_loc[NAMESPACE] == BEL_DEFAULT_NAMESPACE:
-        warnings.warn('Deprecated usage of translocation()')
-        to_loc = compartment_mapping[to_loc[NAME]]
     if not isinstance(to_loc, Entity):
         raise TypeError
 

--- a/src/pybel/io/line_utils.py
+++ b/src/pybel/io/line_utils.py
@@ -225,6 +225,9 @@ def parse_definitions(
 
     logger.info('Finished parsing definitions section in %.02f seconds', time.time() - parse_definitions_start_time)
 
+    metadata_parser.ensure_resources()
+    logger.info('Finished ensuring namespaces in cache')
+
 
 def parse_statements(
     graph: BELGraph,

--- a/src/pybel/language.py
+++ b/src/pybel/language.py
@@ -8,8 +8,7 @@ This module contains mappings between PyBEL's internal constants and BEL languag
 from typing import Optional
 
 from .constants import (
-    ABUNDANCE, BEL_DEFAULT_NAMESPACE, BIOPROCESS, CELL_SURFACE, COMPLEX, COMPOSITE, EXTRACELLULAR, GENE, IDENTIFIER,
-    INTRACELLULAR, MIRNA, NAME, NAMESPACE, PATHOLOGY, PROTEIN, RNA, TRANSCRIBED_TO, TRANSLATED_TO,
+    ABUNDANCE, BIOPROCESS, CELL_SURFACE, COMPLEX, COMPOSITE, EXTRACELLULAR, GENE, IDENTIFIER, INTRACELLULAR, MIRNA, NAME, NAMESPACE, PATHOLOGY, PROTEIN, RNA, TRANSCRIBED_TO, TRANSLATED_TO,
 )
 from .utils import ensure_quotes
 
@@ -73,9 +72,6 @@ class Entity(dict):
     @property
     def curie(self) -> str:
         """Return this entity as a CURIE."""
-        if self[NAMESPACE] == BEL_DEFAULT_NAMESPACE:
-            return self[NAME]
-
         return '{}:{}'.format(
             self.namespace,
             ensure_quotes(self.identifier if self.identifier else self.name),
@@ -552,9 +548,6 @@ gmod_mappings = {
         ],
     },
 }
-
-BEL_DEFAULT_NAMESPACE_VERSION = '2.1.1'
-BEL_DEFAULT_NAMESPACE_URL = 'http://openbel.org/2.1.1.belns'  # just needs something unique... will change later
 
 
 class CitationDict(Entity):

--- a/src/pybel/manager/models.py
+++ b/src/pybel/manager/models.py
@@ -192,7 +192,7 @@ class NamespaceEntry(Base):
         return cls.name.contains(name_query)
 
     def __str__(self):
-        return '[{namespace_id}]{namespace_name}:[{identifier}]{name}'.format(
+        return '[id={namespace_id}] {namespace_name}:{identifier} ! {name}'.format(
             namespace_id=self.namespace.id,
             namespace_name=self.namespace.keyword,
             identifier=self.identifier,

--- a/src/pybel/testing/utils.py
+++ b/src/pybel/testing/utils.py
@@ -6,7 +6,6 @@ from uuid import uuid4
 
 from requests.compat import urlparse
 
-from ..constants import BEL_DEFAULT_NAMESPACE
 from ..manager import Manager
 from ..manager.models import Namespace, NamespaceEntry
 from ..struct import BELGraph
@@ -34,9 +33,6 @@ def n() -> str:
 def make_dummy_namespaces(manager: Manager, graph: BELGraph) -> None:
     """Make dummy namespaces for the test."""
     for keyword, names in get_names(graph).items():
-        if keyword == BEL_DEFAULT_NAMESPACE:
-            continue
-
         graph.namespace_url[keyword] = url = n()
 
         namespace = Namespace(keyword=keyword, url=url)

--- a/tests/test_canonicalization.py
+++ b/tests/test_canonicalization.py
@@ -7,7 +7,7 @@ from typing import Iterable
 
 from pybel import BELGraph
 from pybel.canonicalize import _to_bel_lines_body, postpend_location
-from pybel.constants import BEL_DEFAULT_NAMESPACE, EXTRACELLULAR, INTRACELLULAR, MODIFIER
+from pybel.constants import EXTRACELLULAR, INTRACELLULAR, MODIFIER
 from pybel.dsl import (
     Abundance, BiologicalProcess, ComplexAbundance, CompositeAbundance, EnumeratedFusionRange, Fragment, Gene,
     GeneFusion, GeneModification, Hgvs, MicroRna, NamedComplexAbundance, Pathology, Protein, ProteinModification,
@@ -185,7 +185,7 @@ class TestCanonicalizeEdge(unittest.TestCase):
         )
 
         c4 = self.add_edge(
-            source_modifier=activity('tport', namespace=BEL_DEFAULT_NAMESPACE),
+            source_modifier=activity(name='tport', namespace='', identifier=''),
         )
 
         self.assertEqual(c1, c2)

--- a/tests/test_canonicalization.py
+++ b/tests/test_canonicalization.py
@@ -185,7 +185,7 @@ class TestCanonicalizeEdge(unittest.TestCase):
         )
 
         c4 = self.add_edge(
-            source_modifier=activity(name='tport', namespace='', identifier=''),
+            source_modifier=activity(namespace='go', name='transporter activity', identifier='0005215'),
         )
 
         self.assertEqual(c1, c2)

--- a/tests/test_parse/test_parse_metadata.py
+++ b/tests/test_parse/test_parse_metadata.py
@@ -44,6 +44,7 @@ class TestParseMetadata(FleetingTemporaryCacheMixin):
         """Test that a namespace defined by a URL can't be overwritten by a definition by another URL."""
         s = NAMESPACE_URL_FMT.format(HGNC_KEYWORD, HGNC_URL)
         self.parser.parseString(s)
+        self.parser.ensure_resources()
         help_check_hgnc(self, self.parser.namespace_to_term_to_encoding)
 
         s = NAMESPACE_URL_FMT.format(HGNC_KEYWORD, 'XXXXX')
@@ -57,6 +58,8 @@ class TestParseMetadata(FleetingTemporaryCacheMixin):
         """Test that an annotation defined by a URL can't be overwritten by a definition by a list."""
         s = ANNOTATION_URL_FMT.format(MESH_DISEASES_KEYWORD, MESH_DISEASES_URL)
         self.parser.parseString(s)
+        self.parser.ensure_resources()
+
         self.assertIn(MESH_DISEASES_KEYWORD, self.parser.annotation_to_term)
 
         s = 'DEFINE ANNOTATION {} AS LIST {{"A","B","C"}}'.format(MESH_DISEASES_KEYWORD)
@@ -95,6 +98,7 @@ class TestParseMetadata(FleetingTemporaryCacheMixin):
             'DEFINE ANNOTATION TextLocation AS LIST {"Abstract","Results","Legend","Review"}'
         ]
         self.parser.parse_lines(lines)
+        self.parser.ensure_resources()
 
         self.assertIn(MESH_DISEASES_KEYWORD, self.parser.annotation_to_term)
         self.assertIn(HGNC_KEYWORD, self.parser.namespace_to_term_to_encoding)
@@ -128,6 +132,7 @@ class TestParseMetadata(FleetingTemporaryCacheMixin):
         """Tests parsing a namespace by file URL"""
         s = NAMESPACE_URL_FMT.format('TESTNS1', test_ns_1)
         self.parser.parseString(s)
+        self.parser.ensure_resources()
 
         expected_values = {
             'TestValue1': {'O'},
@@ -150,6 +155,7 @@ class TestParseMetadata(FleetingTemporaryCacheMixin):
         url = Path(test_an_1).as_uri()
         line = ANNOTATION_URL_FMT.format(keyword, url)
         self.parser.parseString(line)
+        self.parser.ensure_resources()
 
         expected_values = {
             'TestAnnot1': 'O',
@@ -159,7 +165,9 @@ class TestParseMetadata(FleetingTemporaryCacheMixin):
             'TestAnnot5': 'O'
         }
 
-        self.assertEqual(set(expected_values), self.parser.manager.get_annotation_entry_names(url))
+        annotation = self.parser.manager.get_namespace_by_url(url)
+        self.assertIsNotNone(annotation)
+        self.assertEqual(set(expected_values), {e.name for e in annotation.entries})
 
     def test_parse_annotation_pattern(self):
         s = r'DEFINE ANNOTATION Test AS PATTERN "\w+"'

--- a/tests/test_struct/test_summary/test_summary_nodes.py
+++ b/tests/test_struct/test_summary/test_summary_nodes.py
@@ -6,7 +6,7 @@ import unittest
 from collections import Counter
 
 from pybel import BELGraph
-from pybel.constants import ABUNDANCE, BEL_DEFAULT_NAMESPACE, BIOPROCESS, COMPLEX, PROTEIN
+from pybel.constants import ABUNDANCE, BIOPROCESS, COMPLEX, PROTEIN
 from pybel.dsl import fusion_range, pathology, protein, protein_fusion
 from pybel.examples import egf_graph, sialic_acid_graph
 from pybel.struct.summary.node_summary import (


### PR DESCRIPTION
This PR makes insertion of namespaces/annotations much faster. It also finishes removing all references to the BEL default namespace, which is no longer necessary as of #455 since all entries in it are automatically upgraded to the corresponding GO terms.