### PR TITLE
Fix bug in creation of DSL objects

### DIFF
--- a/src/pybel/tokens.py
+++ b/src/pybel/tokens.py
@@ -2,7 +2,9 @@
 
 """This module helps handle node data dictionaries."""
 
-from typing import List
+from typing import Any, List, Mapping, Union
+
+from pyparsing import ParseResults
 
 from .constants import (
     CONCEPT, FRAGMENT, FRAGMENT_DESCRIPTION, FRAGMENT_START, FRAGMENT_STOP, FUNCTION, FUSION, FUSION_MISSING,
@@ -34,6 +36,8 @@ def parse_result_to_dsl(tokens) -> BaseEntity:
         return _variant_po_to_dict(tokens)
 
     elif MEMBERS in tokens:
+        if CONCEPT in tokens:
+            return _list_po_with_concept_to_dict(tokens)
         return _list_po_to_dict(tokens)
 
     elif FUSION in tokens:
@@ -193,6 +197,25 @@ def _reaction_po_to_dict(tokens) -> Reaction:
     return Reaction(
         reactants=_parse_tokens_list(tokens[REACTANTS]),
         products=_parse_tokens_list(tokens[PRODUCTS]),
+    )
+
+
+def _list_po_with_concept_to_dict(tokens: Union[ParseResults, Mapping[str, Any]]) -> ListAbundance:
+    """Convert a list parse object to a node.
+
+    :type tokens: ParseResult
+    """
+    func = tokens[FUNCTION]
+    dsl = FUNC_TO_LIST_DSL[func]
+    members = _parse_tokens_list(tokens[MEMBERS])
+
+    concept = tokens[CONCEPT]
+    return dsl(
+        members=members,
+        namespace=concept[NAMESPACE],
+        name=concept.get(NAME),
+        identifier=concept.get(IDENTIFIER),
+        xrefs=tokens.get(XREFS),
     )
 
 

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -4,6 +4,7 @@
 
 import unittest
 
+import pybel.constants as pc
 from pybel import BELGraph
 from pybel.constants import NAME
 from pybel.dsl import (
@@ -12,6 +13,7 @@ from pybel.dsl import (
 )
 from pybel.language import Entity
 from pybel.testing.utils import n
+from pybel.tokens import parse_result_to_dsl
 from pybel.utils import ensure_quotes
 
 
@@ -208,6 +210,20 @@ class TestCentralDogma(unittest.TestCase):
         """Test that the construction of reaction doesn't have empty lists."""
         with self.assertRaises(ReactionEmptyException):
             Reaction([], [])
+
+
+class TestParse(unittest.TestCase):
+    """Test that :func:`parse_result_to_dsl` works correctly."""
+
+    def test_named_complex(self):
+        x = ComplexAbundance(namespace='a', identifier='b', members=[
+            Protein(namespace='c', identifier='d'),
+            Protein(namespace='c', identifier='e'),
+        ])
+
+        y = parse_result_to_dsl(x)
+        self.assertIn(pc.MEMBERS, y)
+        self.assertIn(pc.CONCEPT, y)
 
 
 if __name__ == '__main__':

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -221,7 +221,8 @@ class TestParse(unittest.TestCase):
             Protein(namespace='c', identifier='e'),
         ])
 
-        y = parse_result_to_dsl(x)
+        y = parse_result_to_dsl(dict(x))
+        self.assertIsInstance(y, ComplexAbundance)
         self.assertIn(pc.MEMBERS, y)
         self.assertIn(pc.CONCEPT, y)
 


### PR DESCRIPTION
Closes #464

This PR updates the parse_result_to_dsl function so it can handle named/enumerated complexes