### PR TITLE
Update to work with newer Python

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -31,6 +31,16 @@ ignore =
     E203
     # FIXME later remove this
     D401
+    # warn without stacklevel
+    B028
+    # requests without timeout
+    S113
+    # weak MD5 hash
+    S324
+    # star-arg unpacking after keyword arg
+    B026
+    # loop control var reassigns iterable
+    B020
 exclude =
     .tox,
     .git,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.6", "3.12" ]
+        python-version: [ "3.10", "3.12" ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -32,11 +32,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.6", "3.10" ]
+        python-version: [ "3.10", "3.12" ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -53,18 +53,14 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.10", "3.11", "3.12" ]
         exclude:
           - os: windows-latest
-            python-version: 3.7
-          - os: windows-latest
-            python-version: 3.8
-          - os: windows-latest
-            python-version: 3.9
+            python-version: "3.11"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.6", "3.10" ]
+        python-version: [ "3.6", "3.12" ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.10", "3.13" ]
+        python-version: [ "3.10", "3.14" ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.10", "3.13" ]
+        python-version: [ "3.10", "3.14" ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        python-version: [ "3.10", "3.13" ]
+        python-version: [ "3.10", "3.14" ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.10", "3.12" ]
+        python-version: [ "3.10", "3.13" ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.10", "3.12" ]
+        python-version: [ "3.10", "3.13" ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -53,10 +53,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        python-version: [ "3.10", "3.11", "3.12" ]
-        exclude:
-          - os: windows-latest
-            python-version: "3.11"
+        python-version: [ "3.10", "3.13" ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,7 +73,7 @@ if parsed_version.group('release'):
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -350,7 +350,6 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'networkx': ('https://networkx.github.io/documentation/latest/', None),
-    'py2neo': ('https://py2neo.org/2021.0/', None),
     'sqlalchemy': ('https://docs.sqlalchemy.org/en/latest', None),
     'indra': ('https://indra.readthedocs.io/en/latest/', None),
     'bio2bel': ('https://bio2bel.readthedocs.io/en/latest/', None),

--- a/setup.cfg
+++ b/setup.cfg
@@ -99,7 +99,7 @@ grounding =
     pyobo
     protmapper
 docs =
-    sphinx
+    sphinx<9
     sphinx-rtd-theme
     sphinx-click
     sphinx-autodoc-typehints

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,11 +34,10 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python
+    Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3 :: Only
     Topic :: Scientific/Engineering :: Bio-Informatics
     Topic :: Scientific/Engineering :: Chemistry
@@ -52,8 +51,6 @@ keywords =
 
 [options]
 install_requires =
-    dataclasses; python_version < "3.7"
-    pickle5; python_version < "3.8"
     networkx>=2.4
     sqlalchemy
     click
@@ -77,7 +74,7 @@ install_requires =
 # Random options
 zip_safe = false
 include_package_data = True
-python_requires = >=3.6
+python_requires = >=3.10
 
 # Where is my code
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python
+    Programming Language :: Python :: 3.14
     Programming Language :: Python :: 3.13
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.11

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,7 @@ install_requires =
     ratelimit
     pystow>=0.1.2
     psycopg2-binary
+    setuptools<81
 
 # Random options
 zip_safe = false

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ install_requires =
     more_itertools
     requests
     requests_file
-    pyparsing
+    pyparsing>=3.1.0
     tqdm
     humanize
     tabulate

--- a/src/pybel/examples/sialic_acid_example.py
+++ b/src/pybel/examples/sialic_acid_example.py
@@ -50,16 +50,12 @@ citation = "26438529"
 evidence_1 = """
 Sialic acid binding activates CD33, resulting in phosphorylation of the CD33 immunoreceptor tyrosine-based inhibitory
 motif (ITIM) domains and activation of the SHP-1 and SHP-2 tyrosine phosphatases [66, 67].
-""".replace(
-    "\n", " "
-).strip()
+""".replace("\n", " ").strip()
 
 evidence_2 = """These phosphatases act on multiple substrates, including Syk, to inhibit immune activation [68, 69].
 Hence, CD33 activation leads to increased SHP-1 and SHP-2 activity that antagonizes Syk, inhibiting ITAM-signaling
 proteins, possibly including TREM2/DAP12 (Fig. 1, [70, 71]).
-""".replace(
-    "\n", " "
-).strip()
+""".replace("\n", " ").strip()
 
 sialic_acid_graph = BELGraph(
     name="Sialic Acid Graph",

--- a/src/pybel/grounding.py
+++ b/src/pybel/grounding.py
@@ -54,7 +54,7 @@ from typing import Any, Collection, Mapping, Optional, Tuple, Union
 
 import pyobo
 from protmapper.uniprot_client import get_id_from_mnemonic, get_mnemonic
-from pyobo.getters import NoBuild
+from pyobo.getters import NoBuildError
 from pyobo.identifier_utils import normalize_prefix
 from pyobo.xrefdb.sources.famplex import get_remapping
 from tqdm.autonotebook import tqdm
@@ -397,7 +397,7 @@ def _handle_identifier_not_name(
 
     try:
         id_name_mapping = pyobo.api.names.get_id_name_mapping(prefix)
-    except NoBuild:
+    except NoBuildError:
         return False
 
     if id_name_mapping is None:
@@ -486,7 +486,7 @@ def _handle_name_and_not_identifier(
 
     try:
         id_name_mapping = pyobo.api.names.get_name_id_mapping(prefix)
-    except NoBuild as e:
+    except NoBuildError as e:
         logger.warning("could not get namespace %s - %s", prefix, e)
         return False
 

--- a/src/pybel/grounding.py
+++ b/src/pybel/grounding.py
@@ -53,10 +53,10 @@ import logging
 from typing import Any, Collection, Mapping, Optional, Tuple, Union
 
 import pyobo
+from bioregistry import normalize_prefix
 from protmapper.uniprot_client import get_id_from_mnemonic, get_mnemonic
 from pyobo.getters import NoBuildError
-from pyobo.identifier_utils import normalize_prefix
-from pyobo.xrefdb.sources.famplex import get_remapping
+from pyobo.utils.path import ensure_df
 from tqdm.autonotebook import tqdm
 
 from pybel.constants import (
@@ -106,7 +106,15 @@ logger = logging.getLogger(__name__)
 SKIP = {"ncbigene", "pubchem.compound", "chembl.compound"}
 NO_NAMES = {"fplx", "eccode", "dbsnp", "smiles", "inchi", "inchikey"}
 
-# TODO will get updated
+FAMPLEX_EQUIVALENCES_URL = "https://github.com/sorgerlab/famplex/raw/master/equivalences.csv"
+
+
+def get_remapping() -> Mapping[Tuple[str, str], Tuple[str, str, str]]:
+    """Get a mapping from (prefix, name) pairs to FamPlex (prefix, identifier, name) triples."""
+    df = ensure_df("fplx", url=FAMPLEX_EQUIVALENCES_URL, header=None, names=["prefix", "name", "fplx"], sep=",")
+    return {("bel", name): ("fplx", fplx, fplx) for prefix, name, fplx in df.values if prefix.lower() == "bel"}
+
+
 #: A mapping of (prefix, name) pairs to (prefix, identifier, name) triples
 _NAME_REMAPPING = get_remapping()
 

--- a/src/pybel/io/aws.py
+++ b/src/pybel/io/aws.py
@@ -57,7 +57,7 @@ def to_s3(graph: BELGraph, *, bucket: str, key: str, client: Optional[S3Client] 
             key='your file name.bel.nodelink.json.gz',
         )
 
-    .. warning:: This assumes you already have credentials set up on your machine
+    This assumes you already have credentials set up on your machine.
 
     If you don't already have a bucket, you can create one using ``boto3`` by following
     this tutorial: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-example-creating-buckets.html

--- a/src/pybel/io/jgif.py
+++ b/src/pybel/io/jgif.py
@@ -264,7 +264,7 @@ def from_jgif(graph_jgif_dict, parser_kwargs: Optional[Mapping[str, Any]] = None
             graph.graph[k] = root[k]
 
     parser = BELParser(graph, namespace_to_pattern=NAMESPACE_TO_PATTERN)
-    parser.bel_term.addParseAction(parser.handle_term)
+    parser.bel_term.add_parse_action(parser.handle_term)
 
     for node in root["nodes"]:
         node_label = node.get("label")

--- a/src/pybel/io/spia.py
+++ b/src/pybel/io/spia.py
@@ -169,13 +169,13 @@ def update_spia_matrices(
                 if not isinstance(variant, ProteinModification):
                     continue
                 elif variant.entity.name in UB_NAMES:
-                    spia_matrices["activation_ubiquination"][u_name][v_name] = 1
+                    spia_matrices["activation_ubiquination"].loc[v_name, u_name] = 1
                 elif variant.entity.name in PH_NAMES:
-                    spia_matrices["activation_phosphorylation"][u_name][v_name] = 1
+                    spia_matrices["activation_phosphorylation"].loc[v_name, u_name] = 1
         elif isinstance(v, (Gene, Rna)):  # Normal increase, add activation
-            spia_matrices["expression"][u_name][v_name] = 1
+            spia_matrices["expression"].loc[v_name, u_name] = 1
         else:
-            spia_matrices["activation"][u_name][v_name] = 1
+            spia_matrices["activation"].loc[v_name, u_name] = 1
 
     elif relation in CAUSAL_DECREASE_RELATIONS:
         # If it has pmod check which one and add it to the corresponding matrix
@@ -184,16 +184,16 @@ def update_spia_matrices(
                 if not isinstance(variant, ProteinModification):
                     continue
                 elif variant.entity.name in UB_NAMES:
-                    spia_matrices["inhibition_ubiquination"][u_name][v_name] = 1
+                    spia_matrices["inhibition_ubiquination"].loc[v_name, u_name] = 1
                 elif variant.entity.name in PH_NAMES:
-                    spia_matrices["inhibition_phosphorylation"][u_name][v_name] = 1
+                    spia_matrices["inhibition_phosphorylation"].loc[v_name, u_name] = 1
         elif isinstance(v, (Gene, Rna)):  # Normal decrease, check which matrix
-            spia_matrices["repression"][u_name][v_name] = 1
+            spia_matrices["repression"].loc[v_name, u_name] = 1
         else:
-            spia_matrices["inhibition"][u_name][v_name] = 1
+            spia_matrices["inhibition"].loc[v_name, u_name] = 1
 
     elif relation == ASSOCIATION:
-        spia_matrices["binding_association"][u_name][v_name] = 1
+        spia_matrices["binding_association"].loc[v_name, u_name] = 1
 
 
 def spia_matrices_to_excel(spia_matrices: SPIADataFrames, path: str) -> None:

--- a/src/pybel/parser/baseparser.py
+++ b/src/pybel/parser/baseparser.py
@@ -44,7 +44,7 @@ class BaseParser(object):
         :param line_number: The current line number of the parser
         """
         self._line_number = line_number
-        return self.language.parseString(line)
+        return self.language.parse_string(line)
 
     def get_line_number(self) -> int:
         """Get the current line number."""

--- a/src/pybel/parser/modifiers/constants.py
+++ b/src/pybel/parser/modifiers/constants.py
@@ -2,15 +2,15 @@
 
 """Constants for modifier parsers."""
 
-from pyparsing import Keyword, MatchFirst, oneOf
+from pyparsing import Keyword, MatchFirst, one_of
 
 from ... import language
 from ...exceptions import PlaceholderAminoAcidWarning
 
-aa_single = oneOf(list(language.amino_acid_dict.keys()))
-aa_single.setParseAction(lambda s, l, t: [language.amino_acid_dict[t[0]]])
+aa_single = one_of(list(language.amino_acid_dict.keys()))
+aa_single.set_parse_action(lambda s, l, t: [language.amino_acid_dict[t[0]]])
 
-aa_triple = oneOf(list(language.amino_acid_dict.values()))
+aa_triple = one_of(list(language.amino_acid_dict.values()))
 
 #: In biological literature, the X is used to denote a truncation. Text mining efforts often encode X as an amino
 #: acid, for which we will throw an error using :func:`handle_aa_placeholder`
@@ -22,6 +22,6 @@ def handle_aa_placeholder(line, position, tokens):
     raise PlaceholderAminoAcidWarning(-1, line, position, tokens[0])
 
 
-aa_placeholder.setParseAction(handle_aa_placeholder)
+aa_placeholder.set_parse_action(handle_aa_placeholder)
 
 amino_acid = MatchFirst([aa_triple, aa_single, aa_placeholder])

--- a/src/pybel/parser/modifiers/constants.py
+++ b/src/pybel/parser/modifiers/constants.py
@@ -8,7 +8,7 @@ from ... import language
 from ...exceptions import PlaceholderAminoAcidWarning
 
 aa_single = one_of(list(language.amino_acid_dict.keys()))
-aa_single.set_parse_action(lambda s, l, t: [language.amino_acid_dict[t[0]]])
+aa_single.set_parse_action(lambda s, loc, t: [language.amino_acid_dict[t[0]]])
 
 aa_triple = one_of(list(language.amino_acid_dict.values()))
 

--- a/src/pybel/parser/modifiers/fusion.py
+++ b/src/pybel/parser/modifiers/fusion.py
@@ -37,10 +37,10 @@ it is shown with uppercase letters referring to constants from :code:`pybel.cons
     - PyBEL module :py:class:`pybel.parser.modifiers.get_legacy_fusion_language`
 """
 
-from pyparsing import Group, Keyword, Optional, ParserElement, Suppress, oneOf
+from pyparsing import Group, Keyword, Optional, ParserElement, Suppress, one_of
 from pyparsing import pyparsing_common
 from pyparsing import pyparsing_common as ppc
-from pyparsing import replaceWith
+from pyparsing import replace_with
 
 from ..utils import WCW, nest
 from ...constants import (
@@ -62,8 +62,8 @@ __all__ = [
     "get_legacy_fusion_langauge",
 ]
 
-fusion_tags = oneOf(["fus", "fusion"]).setParseAction(replaceWith(FUSION))
-reference_seq = oneOf(["r", "p", "c"])
+fusion_tags = one_of(["fus", "fusion"]).set_parse_action(replace_with(FUSION))
+reference_seq = one_of(["r", "p", "c"])
 coordinate = pyparsing_common.integer | "?"
 missing = Keyword("?")
 range_coordinate_unquoted = missing(FUSION_MISSING) | (
@@ -88,8 +88,8 @@ def get_fusion_language(concept: ParserElement, permissive: bool = True) -> Pars
 
 def get_legacy_fusion_langauge(concept: ParserElement, reference: str) -> ParserElement:
     """Build a legacy fusion parser."""
-    break_start = (ppc.integer | "?").setParseAction(_fusion_break_handler_wrapper(reference, start=True))
-    break_end = (ppc.integer | "?").setParseAction(_fusion_break_handler_wrapper(reference, start=False))
+    break_start = (ppc.integer | "?").set_parse_action(_fusion_break_handler_wrapper(reference, start=True))
+    break_end = (ppc.integer | "?").set_parse_action(_fusion_break_handler_wrapper(reference, start=False))
 
     res = (
         Group(concept(CONCEPT))(PARTNER_5P)
@@ -101,7 +101,7 @@ def get_legacy_fusion_langauge(concept: ParserElement, reference: str) -> Parser
         )
     )
 
-    res.setParseAction(_fusion_legacy_handler)
+    res.set_parse_action(_fusion_legacy_handler)
     return res
 
 

--- a/src/pybel/parser/modifiers/gene_modification.py
+++ b/src/pybel/parser/modifiers/gene_modification.py
@@ -42,7 +42,7 @@ in the OpenBEL community.
     - PyBEL module :py:func:`pybel.parser.modifiers.get_gene_modification_language`
 """
 
-from pyparsing import Group, MatchFirst, ParserElement, oneOf
+from pyparsing import Group, MatchFirst, ParserElement, one_of
 
 from ..utils import nest, one_of_tags
 from ...constants import CONCEPT, GMOD, IDENTIFIER, KIND, NAME, NAMESPACE
@@ -62,7 +62,7 @@ def _handle_gmod_default(_, __, tokens):
 
 
 gmod_tag = one_of_tags(tags=["gmod", "geneModification"], canonical_tag=GMOD, name=KIND)
-gmod_default_ns = oneOf(list(gmod_namespace)).setParseAction(_handle_gmod_default)
+gmod_default_ns = one_of(list(gmod_namespace)).set_parse_action(_handle_gmod_default)
 
 
 def get_gene_modification_language(

--- a/src/pybel/parser/modifiers/gene_substitution.py
+++ b/src/pybel/parser/modifiers/gene_substitution.py
@@ -32,7 +32,7 @@ The previous statements both produce the underlying data:
 
 import logging
 
-from pyparsing import ParserElement, oneOf
+from pyparsing import ParserElement, one_of
 from pyparsing import pyparsing_common as ppc
 
 from ..utils import nest, one_of_tags
@@ -45,7 +45,7 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
-dna_nucleotide = oneOf(list(language.dna_nucleotide_labels.keys()))
+dna_nucleotide = one_of(list(language.dna_nucleotide_labels.keys()))
 gsub_tag = one_of_tags(tags=["sub", "substitution"], canonical_tag=HGVS, name=KIND)
 
 
@@ -56,7 +56,7 @@ def get_gene_substitution_language() -> ParserElement:
         ppc.integer(GSUB_POSITION),
         dna_nucleotide(GSUB_VARIANT),
     )
-    parser_element.setParseAction(_handle_gsub)
+    parser_element.set_parse_action(_handle_gsub)
     return parser_element
 
 

--- a/src/pybel/parser/modifiers/location.py
+++ b/src/pybel/parser/modifiers/location.py
@@ -44,7 +44,7 @@ This calls for thoughtful consideration of the following two statements:
     - PyBEL module :py:class:`pybel.parser.modifiers.get_location_language`
 """
 
-from pyparsing import Group, ParserElement, Suppress, oneOf
+from pyparsing import Group, ParserElement, Suppress, one_of
 
 from ..utils import nest
 from ...constants import LOCATION
@@ -53,7 +53,7 @@ __all__ = [
     "get_location_language",
 ]
 
-location_tag = Suppress(oneOf(["loc", "location"]))
+location_tag = Suppress(one_of(["loc", "location"]))
 
 
 def get_location_language(identifier: ParserElement) -> ParserElement:

--- a/src/pybel/parser/modifiers/protein_modification.py
+++ b/src/pybel/parser/modifiers/protein_modification.py
@@ -76,7 +76,7 @@ twice to become active. This results in the following:
 
 import logging
 
-from pyparsing import Group, MatchFirst, Optional, ParserElement, ParseResults, oneOf
+from pyparsing import Group, MatchFirst, Optional, ParserElement, ParseResults, one_of
 from pyparsing import pyparsing_common as ppc
 
 from .constants import amino_acid
@@ -120,8 +120,8 @@ def _r(upgraded, tokens):
 
 
 pmod_tag = one_of_tags(tags=["pmod", "proteinModification"], canonical_tag=PMOD, name=KIND)
-pmod_default_ns = oneOf(list(pmod_namespace)).setParseAction(_handle_pmod_default_ns)
-pmod_legacy_ns = oneOf(list(pmod_legacy_labels)).setParseAction(_handle_pmod_legacy_ns)
+pmod_default_ns = one_of(list(pmod_namespace)).set_parse_action(_handle_pmod_default_ns)
+pmod_legacy_ns = one_of(list(pmod_legacy_labels)).set_parse_action(_handle_pmod_legacy_ns)
 
 
 def get_protein_modification_language(

--- a/src/pybel/parser/modifiers/protein_substitution.py
+++ b/src/pybel/parser/modifiers/protein_substitution.py
@@ -56,7 +56,7 @@ def get_protein_substitution_language() -> ParserElement:
         ppc.integer(PSUB_POSITION),
         amino_acid(PSUB_VARIANT),
     )
-    parser_element.setParseAction(_handle_psub)
+    parser_element.set_parse_action(_handle_psub)
     return parser_element
 
 

--- a/src/pybel/parser/modifiers/truncation.py
+++ b/src/pybel/parser/modifiers/truncation.py
@@ -58,9 +58,9 @@ AMINO_ACID = "aminoacid"
 def get_truncation_language() -> ParserElement:
     """Build a parser for protein truncations."""
     l1 = truncation_tag + nest(amino_acid(AMINO_ACID) + ppc.integer(TRUNCATION_POSITION))
-    l1.setParseAction(_handle_trunc)
+    l1.set_parse_action(_handle_trunc)
     l2 = truncation_tag + nest(ppc.integer(TRUNCATION_POSITION))
-    l2.setParseAction(_handle_trunc_legacy)
+    l2.set_parse_action(_handle_trunc_legacy)
     return l1 | l2
 
 

--- a/src/pybel/parser/parse_bel.py
+++ b/src/pybel/parser/parse_bel.py
@@ -18,7 +18,7 @@ from pyparsing import (
     ParseResults,
     StringEnd,
     Suppress,
-    delimited_list,
+    DelimitedList,
     one_of,
     replace_with,
 )
@@ -412,7 +412,7 @@ class BELParser(BaseParser):
         self.general_abundance = general_abundance_tags + nest(concept + opt_location)
 
         self.gene_modified = concept + pyparsing.Optional(
-            WCW + delimited_list(Group(variant | gsub | self.gmod))(VARIANTS),
+            WCW + DelimitedList(Group(variant | gsub | self.gmod))(VARIANTS),
         )
 
         self.gene_fusion = Group(self.fusion)(FUSION)
@@ -433,7 +433,7 @@ class BELParser(BaseParser):
         self.mirna_modified = (
             concept
             + pyparsing.Optional(
-                WCW + delimited_list(Group(variant))(VARIANTS),
+                WCW + DelimitedList(Group(variant))(VARIANTS),
             )
             + opt_location
         )
@@ -443,7 +443,7 @@ class BELParser(BaseParser):
 
         self.protein_modified = concept + pyparsing.Optional(
             WCW
-            + delimited_list(Group(MatchFirst([self.pmod, variant, fragment, psub, trunc])))(
+            + DelimitedList(Group(MatchFirst([self.pmod, variant, fragment, psub, trunc])))(
                 VARIANTS,
             ),
         )
@@ -463,7 +463,7 @@ class BELParser(BaseParser):
             + opt_location,
         )
 
-        self.rna_modified = concept + pyparsing.Optional(WCW + delimited_list(Group(variant))(VARIANTS))
+        self.rna_modified = concept + pyparsing.Optional(WCW + DelimitedList(Group(variant))(VARIANTS))
 
         self.rna_fusion = Group(self.fusion)(FUSION)
         self.rna_fusion_legacy = Group(get_legacy_fusion_langauge(concept, "r"))(FUSION)
@@ -497,7 +497,7 @@ class BELParser(BaseParser):
         self.complex_singleton = complex_tag + nest(concept + opt_location)
 
         self.complex_list = complex_tag + nest(
-            delimited_list(Group(self.single_abundance | self.complex_singleton))(MEMBERS) + opt_location,
+            DelimitedList(Group(self.single_abundance | self.complex_singleton))(MEMBERS) + opt_location,
         )
 
         self.complex_abundances = self.complex_list | self.complex_singleton
@@ -508,7 +508,7 @@ class BELParser(BaseParser):
 
         #: `2.1.3 <http://openbel.org/language/version_2.0/bel_specification_version_2.0.html#XcompositeA>`_
         self.composite_abundance = composite_abundance_tag + nest(
-            delimited_list(Group(self.simple_abundance))(MEMBERS) + opt_location,
+            DelimitedList(Group(self.simple_abundance))(MEMBERS) + opt_location,
         )
 
         self.abundance = self.simple_abundance | self.composite_abundance
@@ -587,8 +587,8 @@ class BELParser(BaseParser):
         self.degradation = degradation_tags + nest(self.simple_abundance)
 
         #: `2.5.3 <http://openbel.org/language/version_2.0/bel_specification_version_2.0.html#_reaction_rxn>`_
-        self.reactants = Suppress(REACTANTS) + nest(delimited_list(Group(self.simple_abundance)))
-        self.products = Suppress(PRODUCTS) + nest(delimited_list(Group(self.simple_abundance)))
+        self.reactants = Suppress(REACTANTS) + nest(DelimitedList(Group(self.simple_abundance)))
+        self.products = Suppress(PRODUCTS) + nest(DelimitedList(Group(self.simple_abundance)))
 
         self.reaction = reaction_tags + nest(Group(self.reactants)(REACTANTS), Group(self.products)(PRODUCTS))
 
@@ -653,7 +653,7 @@ class BELParser(BaseParser):
         self.has_member = triple(self.abundance, has_member_tag, self.abundance)
 
         #: `3.4.2 <http://openbel.org/language/version_2.0/bel_specification_version_2.0.html#_hasmembers>`_
-        self.abundance_list = Suppress("list") + nest(delimited_list(Group(self.abundance)))
+        self.abundance_list = Suppress("list") + nest(DelimitedList(Group(self.abundance)))
 
         self.has_members = triple(self.abundance, has_members_tag, self.abundance_list)
         self.has_members.set_parse_action(self.handle_has_members)

--- a/src/pybel/parser/parse_bel.py
+++ b/src/pybel/parser/parse_bel.py
@@ -12,13 +12,13 @@ from typing import Any, Dict, List, Mapping, Optional, Pattern, Set, Union
 
 import pyparsing
 from pyparsing import (
+    DelimitedList,
     Group,
     Keyword,
     MatchFirst,
     ParseResults,
     StringEnd,
     Suppress,
-    DelimitedList,
     one_of,
     replace_with,
 )

--- a/src/pybel/parser/parse_bel.py
+++ b/src/pybel/parser/parse_bel.py
@@ -18,9 +18,9 @@ from pyparsing import (
     ParseResults,
     StringEnd,
     Suppress,
-    delimitedList,
-    oneOf,
-    replaceWith,
+    delimited_list,
+    one_of,
+    replace_with,
 )
 
 from .baseparser import BaseParser
@@ -188,7 +188,7 @@ population_tag = one_of_tags(["pop", "populationAbundance"], POPULATION, FUNCTIO
 activity_tag = one_of_tags(["act", "activity"], ACTIVITY, MODIFIER)
 
 #: 2.4.1 http://openbel.org/language/version_2.0/bel_specification_version_2.0.html#XmolecularA
-molecular_activity_tags = Suppress(oneOf(["ma", "molecularActivity"]))
+molecular_activity_tags = Suppress(one_of(["ma", "molecularActivity"]))
 
 ################################
 # 2.5 Transformation Functions #
@@ -214,7 +214,7 @@ reaction_tags = one_of_tags(["reaction", "rxn"], REACTION, FUNCTION)
 #####################
 
 #: `3.1.1 <http://openbel.org/language/version_2.0/bel_specification_version_2.0.html#Xincreases>`_
-increases_tag = oneOf(["->", "→", "increases"]).setParseAction(replaceWith(INCREASES))
+increases_tag = one_of(["->", "→", "increases"]).set_parse_action(replace_with(INCREASES))
 
 #: `3.1.2 <http://openbel.org/language/version_2.0/bel_specification_version_2.0.html#XdIncreases>`_
 directly_increases_tag = one_of_tags(["=>", "⇒", "directlyIncreases"], DIRECTLY_INCREASES)
@@ -256,10 +256,10 @@ association_tag = one_of_tags(["--", "association"], ASSOCIATION)
 orthologous_tag = Keyword("orthologous")
 
 #: `3.3.2 <http://openbel.org/language/version_2.0/bel_specification_version_2.0.html#_transcribedto>`_
-transcribed_tag = oneOf([":>", "transcribedTo"]).setParseAction(replaceWith(TRANSCRIBED_TO))
+transcribed_tag = one_of([":>", "transcribedTo"]).set_parse_action(replace_with(TRANSCRIBED_TO))
 
 #: `3.3.3 <http://openbel.org/language/version_2.0/bel_specification_version_2.0.html#_translatedto>`_
-translated_tag = oneOf([">>", "translatedTo"]).setParseAction(replaceWith(TRANSLATED_TO))
+translated_tag = one_of([">>", "translatedTo"]).set_parse_action(replace_with(TRANSLATED_TO))
 
 #: `3.4.1 <http://openbel.org/language/version_2.0/bel_specification_version_2.0.html#_hasmember>`_
 has_member_tag = Keyword("hasMember")
@@ -412,7 +412,7 @@ class BELParser(BaseParser):
         self.general_abundance = general_abundance_tags + nest(concept + opt_location)
 
         self.gene_modified = concept + pyparsing.Optional(
-            WCW + delimitedList(Group(variant | gsub | self.gmod))(VARIANTS),
+            WCW + delimited_list(Group(variant | gsub | self.gmod))(VARIANTS),
         )
 
         self.gene_fusion = Group(self.fusion)(FUSION)
@@ -433,7 +433,7 @@ class BELParser(BaseParser):
         self.mirna_modified = (
             concept
             + pyparsing.Optional(
-                WCW + delimitedList(Group(variant))(VARIANTS),
+                WCW + delimited_list(Group(variant))(VARIANTS),
             )
             + opt_location
         )
@@ -443,7 +443,7 @@ class BELParser(BaseParser):
 
         self.protein_modified = concept + pyparsing.Optional(
             WCW
-            + delimitedList(Group(MatchFirst([self.pmod, variant, fragment, psub, trunc])))(
+            + delimited_list(Group(MatchFirst([self.pmod, variant, fragment, psub, trunc])))(
                 VARIANTS,
             ),
         )
@@ -463,7 +463,7 @@ class BELParser(BaseParser):
             + opt_location,
         )
 
-        self.rna_modified = concept + pyparsing.Optional(WCW + delimitedList(Group(variant))(VARIANTS))
+        self.rna_modified = concept + pyparsing.Optional(WCW + delimited_list(Group(variant))(VARIANTS))
 
         self.rna_fusion = Group(self.fusion)(FUSION)
         self.rna_fusion_legacy = Group(get_legacy_fusion_langauge(concept, "r"))(FUSION)
@@ -497,18 +497,18 @@ class BELParser(BaseParser):
         self.complex_singleton = complex_tag + nest(concept + opt_location)
 
         self.complex_list = complex_tag + nest(
-            delimitedList(Group(self.single_abundance | self.complex_singleton))(MEMBERS) + opt_location,
+            delimited_list(Group(self.single_abundance | self.complex_singleton))(MEMBERS) + opt_location,
         )
 
         self.complex_abundances = self.complex_list | self.complex_singleton
 
         # Definition of all simple abundances that can be used in a composite abundance
         self.simple_abundance = self.complex_abundances | self.single_abundance
-        self.simple_abundance.setParseAction(self.check_function_semantics)
+        self.simple_abundance.set_parse_action(self.check_function_semantics)
 
         #: `2.1.3 <http://openbel.org/language/version_2.0/bel_specification_version_2.0.html#XcompositeA>`_
         self.composite_abundance = composite_abundance_tag + nest(
-            delimitedList(Group(self.simple_abundance))(MEMBERS) + opt_location,
+            delimited_list(Group(self.simple_abundance))(MEMBERS) + opt_location,
         )
 
         self.abundance = self.simple_abundance | self.composite_abundance
@@ -516,7 +516,7 @@ class BELParser(BaseParser):
         # 2.4 Process Modifier Function
         # backwards compatibility with BEL v1.0
 
-        molecular_activity_default = oneOf(list(language.activity_labels)).setParseAction(
+        molecular_activity_default = one_of(list(language.activity_labels)).set_parse_action(
             handle_molecular_activity_default,
         )
 
@@ -534,15 +534,15 @@ class BELParser(BaseParser):
         self.pathology = pathology_tag + nest(concept)
 
         self.bp_path = self.biological_process | self.pathology
-        self.bp_path.setParseAction(self.check_function_semantics)
+        self.bp_path.set_parse_action(self.check_function_semantics)
 
         self.activity_standard = activity_tag + nest(
             self.simple_abundance + pyparsing.Optional(WCW + Group(self.molecular_activity)(EFFECT)),
         )
 
-        activity_legacy_tags = oneOf(language.activities)(MODIFIER)
+        activity_legacy_tags = one_of(language.activities)(MODIFIER)
         self.activity_legacy = activity_legacy_tags + nest(self.simple_abundance)
-        self.activity_legacy.setParseAction(handle_activity_legacy)
+        self.activity_legacy.set_parse_action(handle_activity_legacy)
 
         #: `2.3.3 <http://openbel.org/language/version_2.0/bel_specification_version_2.0.html#Xactivity>`_
         self.activity = self.activity_standard | self.activity_legacy
@@ -555,10 +555,10 @@ class BELParser(BaseParser):
         to_loc = Suppress(TO_LOC) + nest(concept(TO_LOC))
 
         self.cell_secretion = cell_secretion_tag + nest(self.simple_abundance)
-        self.cell_secretion.addParseAction(handle_secretion)
+        self.cell_secretion.add_parse_action(handle_secretion)
 
         self.cell_surface_expression = cell_surface_expression_tag + nest(self.simple_abundance)
-        self.cell_surface_expression.addParseAction(handle_surface_expression)
+        self.cell_surface_expression.add_parse_action(handle_surface_expression)
 
         self.translocation_standard = nest(
             self.simple_abundance + WCW + Group(from_loc + WCW + to_loc)(EFFECT),
@@ -568,11 +568,11 @@ class BELParser(BaseParser):
             self.simple_abundance + WCW + Group(concept(FROM_LOC) + WCW + concept(TO_LOC))(EFFECT),
         )
 
-        self.translocation_legacy.addParseAction(handle_legacy_tloc)
+        self.translocation_legacy.add_parse_action(handle_legacy_tloc)
         self.translocation_unqualified = nest(self.simple_abundance)
 
         if self.disallow_unqualified_translocations:
-            self.translocation_unqualified.setParseAction(self.handle_translocation_illegal)
+            self.translocation_unqualified.set_parse_action(self.handle_translocation_illegal)
 
         #: `2.5.1 <http://openbel.org/language/version_2.0/bel_specification_version_2.0.html#_translocations>`_
         self.translocation = translocation_tag + MatchFirst(
@@ -587,8 +587,8 @@ class BELParser(BaseParser):
         self.degradation = degradation_tags + nest(self.simple_abundance)
 
         #: `2.5.3 <http://openbel.org/language/version_2.0/bel_specification_version_2.0.html#_reaction_rxn>`_
-        self.reactants = Suppress(REACTANTS) + nest(delimitedList(Group(self.simple_abundance)))
-        self.products = Suppress(PRODUCTS) + nest(delimitedList(Group(self.simple_abundance)))
+        self.reactants = Suppress(REACTANTS) + nest(delimited_list(Group(self.simple_abundance)))
+        self.products = Suppress(PRODUCTS) + nest(delimited_list(Group(self.simple_abundance)))
 
         self.reaction = reaction_tags + nest(Group(self.reactants)(REACTANTS), Group(self.products)(PRODUCTS))
 
@@ -653,13 +653,13 @@ class BELParser(BaseParser):
         self.has_member = triple(self.abundance, has_member_tag, self.abundance)
 
         #: `3.4.2 <http://openbel.org/language/version_2.0/bel_specification_version_2.0.html#_hasmembers>`_
-        self.abundance_list = Suppress("list") + nest(delimitedList(Group(self.abundance)))
+        self.abundance_list = Suppress("list") + nest(delimited_list(Group(self.abundance)))
 
         self.has_members = triple(self.abundance, has_members_tag, self.abundance_list)
-        self.has_members.setParseAction(self.handle_has_members)
+        self.has_members.set_parse_action(self.handle_has_members)
 
         self.has_components = triple(self.abundance, has_components_tag, self.abundance_list)
-        self.has_components.setParseAction(self.handle_has_components)
+        self.has_components.set_parse_action(self.handle_has_components)
 
         self.has_list = self.has_members | self.has_components
 
@@ -690,7 +690,7 @@ class BELParser(BaseParser):
             ]
         )
         if self.graph is not None:
-            self.relation.setParseAction(self._handle_relation_harness)
+            self.relation.set_parse_action(self._handle_relation_harness)
 
         self.inverted_unqualified_relation = MatchFirst(
             [
@@ -699,7 +699,7 @@ class BELParser(BaseParser):
             ]
         )
         if self.graph is not None:
-            self.inverted_unqualified_relation.setParseAction(self.handle_inverse_unqualified_relation)
+            self.inverted_unqualified_relation.set_parse_action(self.handle_inverse_unqualified_relation)
 
         self.normal_unqualified_relation = MatchFirst(
             [
@@ -710,7 +710,7 @@ class BELParser(BaseParser):
             ]
         )
         if self.graph is not None:
-            self.normal_unqualified_relation.setParseAction(self.handle_unqualified_relation)
+            self.normal_unqualified_relation.set_parse_action(self.handle_unqualified_relation)
 
         #: 3.1 Causal Relationships - nested.
         causal_relation_tags = MatchFirst(
@@ -729,7 +729,7 @@ class BELParser(BaseParser):
         )
 
         if self.graph is not None:
-            self.nested_causal_relationship.setParseAction(self.handle_nested_relation)
+            self.nested_causal_relationship.set_parse_action(self.handle_nested_relation)
 
         # has_members is handled differently from all other relations becuase it gets distrinbuted
         self.relation = MatchFirst(
@@ -744,17 +744,17 @@ class BELParser(BaseParser):
 
         self.singleton_term = self.bel_term + StringEnd()
         if self.graph is not None:
-            self.singleton_term.setParseAction(self.handle_term)
+            self.singleton_term.set_parse_action(self.handle_term)
 
         self.statement = self.relation | self.singleton_term
         self.language = self.control_parser.language | self.statement
-        self.language.setName("BEL")
+        self.language.set_name("BEL")
 
         super(BELParser, self).__init__(self.language, streamline=autostreamline)
 
     def parse(self, s: str) -> Mapping[str, Any]:
         """Parse the string."""
-        return self.parseString(s).asDict()
+        return self.parseString(s).as_dict()
 
     @property
     def _namespace_dict(self) -> Mapping[str, Mapping[str, str]]:
@@ -1060,7 +1060,7 @@ def modifier_po_to_dict(tokens):
 
         if EFFECT in tokens:
             try:
-                attrs[EFFECT] = tokens[EFFECT].asDict()
+                attrs[EFFECT] = tokens[EFFECT].as_dict()
             except AttributeError:  # for when it was auto-upgraded
                 attrs[EFFECT] = dict(tokens[EFFECT])
 

--- a/src/pybel/parser/parse_concept.py
+++ b/src/pybel/parser/parse_concept.py
@@ -70,8 +70,8 @@ class ConceptParser(BaseParser):
             self.namespace_to_identifier_to_encoding = {}
 
         if not skip_validation:
-            self.identifier_fqualified.setParseAction(self.handle_identifier_fqualified)
-            self.identifier_qualified.setParseAction(self.handle_identifier_qualified)
+            self.identifier_fqualified.set_parse_action(self.handle_identifier_fqualified)
+            self.identifier_qualified.set_parse_action(self.handle_identifier_qualified)
 
         self.namespace_to_pattern = namespace_to_pattern or {}
         if ensure_go and "go" not in self.namespace_to_name_to_encoding:
@@ -81,7 +81,7 @@ class ConceptParser(BaseParser):
         self.allow_naked_names = allow_naked_names
 
         self.identifier_bare = (ns | quote)(NAME)
-        self.identifier_bare.setParseAction(
+        self.identifier_bare.set_parse_action(
             self.handle_namespace_default
             if self.default_namespace
             else self.handle_namespace_lenient

--- a/src/pybel/parser/parse_concept.py
+++ b/src/pybel/parser/parse_concept.py
@@ -82,11 +82,11 @@ class ConceptParser(BaseParser):
 
         self.identifier_bare = (ns | quote)(NAME)
         self.identifier_bare.set_parse_action(
-            self.handle_namespace_default
-            if self.default_namespace
-            else self.handle_namespace_lenient
-            if self.allow_naked_names
-            else self.handle_namespace_invalid,
+            (
+                self.handle_namespace_default
+                if self.default_namespace
+                else self.handle_namespace_lenient if self.allow_naked_names else self.handle_namespace_invalid
+            ),
         )
 
         super().__init__(

--- a/src/pybel/parser/parse_control.py
+++ b/src/pybel/parser/parse_control.py
@@ -12,7 +12,7 @@ This module handles parsing control statement, which add annotations and namespa
 import logging
 from typing import Any, Dict, List, Mapping, Optional, Pattern, Set
 
-from pyparsing import And, Keyword, MatchFirst, ParseResults, Suppress, oneOf
+from pyparsing import And, Keyword, MatchFirst, ParseResults, Suppress, one_of
 from pyparsing import pyparsing_common as ppc
 
 from .baseparser import BaseParser
@@ -52,7 +52,7 @@ set_tag = Keyword(BEL_KEYWORD_SET)
 unset_tag = Keyword(BEL_KEYWORD_UNSET)
 unset_all = Suppress(BEL_KEYWORD_ALL)
 
-supporting_text_tags = oneOf([BEL_KEYWORD_EVIDENCE, BEL_KEYWORD_SUPPORT])
+supporting_text_tags = one_of([BEL_KEYWORD_EVIDENCE, BEL_KEYWORD_SUPPORT])
 
 set_statement_group_stub = And([Suppress(BEL_KEYWORD_STATEMENT_GROUP), Suppress("="), qid("group")])
 set_citation_stub = And([Suppress(BEL_KEYWORD_CITATION), Suppress("="), delimited_quoted_list("values")])
@@ -97,35 +97,35 @@ class ControlParser(BaseParser):
         self.annotations = {}
         self.required_annotations = required_annotations or []
 
-        annotation_key = ppc.identifier("key").setParseAction(self.handle_annotation_key)
+        annotation_key = ppc.identifier("key").set_parse_action(self.handle_annotation_key)
 
-        self.set_statement_group = set_statement_group_stub().setParseAction(self.handle_set_statement_group)
-        self.set_citation = set_citation_stub.setParseAction(self.handle_set_citation)
-        self.set_evidence = set_evidence_stub.setParseAction(self.handle_set_evidence)
+        self.set_statement_group = set_statement_group_stub().set_parse_action(self.handle_set_statement_group)
+        self.set_citation = set_citation_stub.set_parse_action(self.handle_set_citation)
+        self.set_evidence = set_evidence_stub.set_parse_action(self.handle_set_evidence)
 
         set_command_prefix = And([annotation_key("key"), Suppress("=")])
         self.set_command = set_command_prefix + qid("value")
-        self.set_command.setParseAction(self.handle_set_command)
+        self.set_command.set_parse_action(self.handle_set_command)
 
         self.set_command_list = set_command_prefix + delimited_quoted_list("values")
-        self.set_command_list.setParseAction(self.handle_set_command_list)
+        self.set_command_list.set_parse_action(self.handle_set_command_list)
 
         self.unset_command = annotation_key("key")
-        self.unset_command.addParseAction(self.handle_unset_command)
+        self.unset_command.add_parse_action(self.handle_unset_command)
 
         self.unset_evidence = supporting_text_tags(EVIDENCE)
-        self.unset_evidence.setParseAction(self.handle_unset_evidence)
+        self.unset_evidence.set_parse_action(self.handle_unset_evidence)
 
         self.unset_citation = Suppress(BEL_KEYWORD_CITATION)
-        self.unset_citation.setParseAction(self.handle_unset_citation)
+        self.unset_citation.set_parse_action(self.handle_unset_citation)
 
         self.unset_statement_group = Suppress(BEL_KEYWORD_STATEMENT_GROUP)
-        self.unset_statement_group.setParseAction(self.handle_unset_statement_group)
+        self.unset_statement_group.set_parse_action(self.handle_unset_statement_group)
 
         self.unset_list = delimited_unquoted_list("values")
-        self.unset_list.setParseAction(self.handle_unset_list)
+        self.unset_list.set_parse_action(self.handle_unset_list)
 
-        self.unset_all = unset_all.setParseAction(self.handle_unset_all)
+        self.unset_all = unset_all.set_parse_action(self.handle_unset_all)
 
         self.set_statements = set_tag("action") + MatchFirst(
             [

--- a/src/pybel/parser/parse_metadata.py
+++ b/src/pybel/parser/parse_metadata.py
@@ -139,12 +139,12 @@ class MetadataParser(BaseParser):
         self.annotation_list = And([annotation_tag, list_tag, delimited_quoted_list("values")])
         self.annotation_pattern = And([annotation_tag, Suppress(BEL_KEYWORD_PATTERN), quote("value")])
 
-        self.document.setParseAction(self.handle_document)
-        self.namespace_url.setParseAction(self.handle_namespace_url)
-        self.namespace_pattern.setParseAction(self.handle_namespace_pattern)
-        self.annotation_url.setParseAction(self.handle_annotations_url)
-        self.annotation_list.setParseAction(self.handle_annotation_list)
-        self.annotation_pattern.setParseAction(self.handle_annotation_pattern)
+        self.document.set_parse_action(self.handle_document)
+        self.namespace_url.set_parse_action(self.handle_namespace_url)
+        self.namespace_pattern.set_parse_action(self.handle_namespace_pattern)
+        self.annotation_url.set_parse_action(self.handle_annotations_url)
+        self.annotation_list.set_parse_action(self.handle_annotation_list)
+        self.annotation_pattern.set_parse_action(self.handle_annotation_pattern)
 
         self.language = MatchFirst(
             [
@@ -155,7 +155,7 @@ class MetadataParser(BaseParser):
                 self.annotation_pattern,
                 self.namespace_pattern,
             ]
-        ).setName("BEL Metadata")
+        ).set_name("BEL Metadata")
 
         super().__init__(self.language)
 

--- a/src/pybel/parser/utils.py
+++ b/src/pybel/parser/utils.py
@@ -16,7 +16,7 @@ from pyparsing import (
     ZeroOrMore,
     alphanums,
     dblQuotedString,
-    delimited_list,
+    DelimitedList,
     one_of,
     removeQuotes,
     replace_with,
@@ -52,8 +52,8 @@ ns = Word(alphanums + "_-.")
 identifier = Word(alphanums + "_")
 quote = dblQuotedString().set_parse_action(removeQuotes)
 qid = quote | identifier
-delimited_quoted_list = And([Suppress("{"), delimited_list(quote), Suppress("}")])
-delimited_unquoted_list = And([Suppress("{"), delimited_list(identifier), Suppress("}")])
+delimited_quoted_list = And([Suppress("{"), DelimitedList(quote), Suppress("}")])
+delimited_unquoted_list = And([Suppress("{"), DelimitedList(identifier), Suppress("}")])
 
 
 def nest(*content):

--- a/src/pybel/parser/utils.py
+++ b/src/pybel/parser/utils.py
@@ -16,10 +16,10 @@ from pyparsing import (
     ZeroOrMore,
     alphanums,
     dblQuotedString,
-    delimitedList,
-    oneOf,
+    delimited_list,
+    one_of,
     removeQuotes,
-    replaceWith,
+    replace_with,
 )
 
 from ..constants import RELATION, SOURCE, TARGET
@@ -50,10 +50,10 @@ RP = W + Suppress(")")
 word = Word(alphanums)
 ns = Word(alphanums + "_-.")
 identifier = Word(alphanums + "_")
-quote = dblQuotedString().setParseAction(removeQuotes)
+quote = dblQuotedString().set_parse_action(removeQuotes)
 qid = quote | identifier
-delimited_quoted_list = And([Suppress("{"), delimitedList(quote), Suppress("}")])
-delimited_unquoted_list = And([Suppress("{"), delimitedList(identifier), Suppress("}")])
+delimited_quoted_list = And([Suppress("{"), delimited_list(quote), Suppress("}")])
+delimited_unquoted_list = And([Suppress("{"), delimited_list(identifier), Suppress("}")])
 
 
 def nest(*content):
@@ -79,12 +79,12 @@ def one_of_tags(
                             (note capitalization) is used for the abundance of a gene
     :param name: this is the key under which the value for this tag is put in the PyParsing framework.
     """
-    element = oneOf(tags).setParseAction(replaceWith(canonical_tag))
+    element = one_of(tags).set_parse_action(replace_with(canonical_tag))
 
     if name is None:
         return element
 
-    return element.setResultsName(name)
+    return element.set_results_name(name)
 
 
 def triple(subject, relation, obj) -> ParserElement:

--- a/src/pybel/parser/utils.py
+++ b/src/pybel/parser/utils.py
@@ -8,6 +8,7 @@ from typing import Any, List, Optional
 
 from pyparsing import (
     And,
+    DelimitedList,
     Group,
     ParserElement,
     Suppress,
@@ -16,7 +17,6 @@ from pyparsing import (
     ZeroOrMore,
     alphanums,
     dblQuotedString,
-    DelimitedList,
     one_of,
     removeQuotes,
     replace_with,

--- a/src/pybel/struct/graph.py
+++ b/src/pybel/struct/graph.py
@@ -1216,8 +1216,7 @@ class SummarizeDispatch(Dispatch):
     def _repr_html_(self) -> str:
         from .summary import supersummary as ss
 
-        return dedent(
-            f"""\
+        return dedent(f"""\
             <h2>Metadata</h2>
             {tabulate(self._metadata_list(), tablefmt='html')}
             <h2>Statistics</h2>
@@ -1228,8 +1227,7 @@ class SummarizeDispatch(Dispatch):
             {ss.namespaces_str(self.graph, examples=True, add_count=False, tablefmt='html')}
             <h2>Edges</h2>
             {ss.edges_str(self.graph, examples=True, add_count=False, tablefmt='html')}
-        """
-        )
+        """)
 
     def statistics(self, file: Optional[TextIO] = None):
         """Print summary statistics on the graph."""

--- a/src/pybel/struct/mutation/induction/paths.py
+++ b/src/pybel/struct/mutation/induction/paths.py
@@ -123,7 +123,7 @@ def get_random_path(graph: BELGraph) -> List[BaseEntity]:
 
     def pick_random_pair() -> Tuple[BaseEntity, BaseEntity]:
         """Get a pair of random nodes."""
-        return random.sample(nodes, k=2)
+        return random.sample(list(nodes), k=2)
 
     source, target = pick_random_pair()
 

--- a/src/pybel/struct/summary/node_summary.py
+++ b/src/pybel/struct/summary/node_summary.py
@@ -97,7 +97,7 @@ def _iterate_namespaces(graph: BELGraph) -> Iterable[str]:
 
 
 def _iterate_edge_entities(graph: BELGraph) -> Iterable[Entity]:
-    for ((_, _, data), side) in itt.product(graph.edges(data=True), (SOURCE_MODIFIER, TARGET_MODIFIER)):
+    for (_, _, data), side in itt.product(graph.edges(data=True), (SOURCE_MODIFIER, TARGET_MODIFIER)):
         side_data = data.get(side)
         if side_data is None:
             continue
@@ -224,7 +224,7 @@ def _identifier_filtered_iterator(graph) -> Iterable[Tuple[str, str]]:
             for pair in _get_node_names(member):
                 yield pair
 
-    for ((_, _, data), side) in itt.product(graph.edges(data=True), (SOURCE_MODIFIER, TARGET_MODIFIER)):
+    for (_, _, data), side in itt.product(graph.edges(data=True), (SOURCE_MODIFIER, TARGET_MODIFIER)):
         side_data = data.get(side)
         if side_data is None:
             continue

--- a/src/pybel/testing/cases.py
+++ b/src/pybel/testing/cases.py
@@ -41,6 +41,7 @@ class TemporaryCacheMixin(unittest.TestCase):
     def tearDown(self):
         """Tear down the test function by closing the session and removing the database."""
         self.manager.session.close()
+        self.manager.engine.dispose()
 
         if not TEST_CONNECTION:
             os.close(self.fd)

--- a/src/pybel/testing/cases.py
+++ b/src/pybel/testing/cases.py
@@ -71,6 +71,7 @@ class TemporaryCacheClsMixin(unittest.TestCase):
     def tearDownClass(cls):
         """Tear down the test class by closing the session and removing the database."""
         cls.manager.session.close()
+        cls.manager.engine.dispose()
 
         if not TEST_CONNECTION:
             os.close(cls.fd)

--- a/tests/test_io/test_spia.py
+++ b/tests/test_io/test_spia.py
@@ -48,7 +48,7 @@ class TestSpia(unittest.TestCase):
         sub = protein(namespace="HGNC", name="A", identifier="1")
         obj = protein(namespace="HGNC", name="B", identifier="2", variants=[pmod("Ub")])
 
-        index = {"A", "B"}
+        index = ["A", "B"]
 
         test_dict = {}
 
@@ -71,7 +71,7 @@ class TestSpia(unittest.TestCase):
         sub = protein(namespace="HGNC", name="A", identifier="1")
         obj = protein(namespace="HGNC", name="B", identifier="2", variants=[pmod("Ub")])
 
-        index = {"A", "B"}
+        index = ["A", "B"]
 
         test_dict = {}
 
@@ -91,7 +91,7 @@ class TestSpia(unittest.TestCase):
         sub = protein(namespace="HGNC", name="A", identifier="1")
         obj = protein(namespace="HGNC", name="B", identifier="2", variants=[pmod("Ph")])
 
-        index = {"A", "B"}
+        index = ["A", "B"]
 
         test_dict = {}
 
@@ -112,7 +112,7 @@ class TestSpia(unittest.TestCase):
         sub = protein(namespace="HGNC", name="A", identifier="1")
         obj = protein(namespace="HGNC", name="B", identifier="2", variants=[pmod("Ph")])
 
-        index = {"A", "B"}
+        index = ["A", "B"]
 
         test_dict = {}
 
@@ -132,7 +132,7 @@ class TestSpia(unittest.TestCase):
         sub = protein(namespace="HGNC", name="A", identifier="1")
         obj = rna(namespace="HGNC", name="B", identifier="2")
 
-        index = {"A", "B"}
+        index = ["A", "B"]
 
         test_dict = {}
 
@@ -152,7 +152,7 @@ class TestSpia(unittest.TestCase):
         sub = protein(namespace="HGNC", name="A", identifier="1")
         obj = rna(namespace="HGNC", name="B", identifier="2")
 
-        index = {"A", "B"}
+        index = ["A", "B"]
 
         test_dict = {}
 
@@ -172,7 +172,7 @@ class TestSpia(unittest.TestCase):
         sub = protein(namespace="HGNC", name="A", identifier="1")
         obj = protein(namespace="HGNC", name="B", identifier="2")
 
-        index = {"A", "B"}
+        index = ["A", "B"]
 
         test_dict = {}
 
@@ -192,7 +192,7 @@ class TestSpia(unittest.TestCase):
         sub = protein(namespace="HGNC", name="A", identifier="1")
         obj = protein(namespace="HGNC", name="B", identifier="2")
 
-        index = {"A", "B"}
+        index = ["A", "B"]
 
         test_dict = {}
 
@@ -212,7 +212,7 @@ class TestSpia(unittest.TestCase):
         sub = protein(namespace="HGNC", name="A", identifier="1")
         obj = protein(namespace="HGNC", name="B", identifier="2")
 
-        index = {"A", "B"}
+        index = ["A", "B"]
 
         test_dict = {}
 
@@ -237,7 +237,7 @@ class TestSpia(unittest.TestCase):
             variants=[pmod("Ub"), pmod("Ph")],
         )
 
-        index = {"A", "B"}
+        index = ["A", "B"]
 
         test_dict = {}
 

--- a/tests/test_manager/test_connection.py
+++ b/tests/test_manager/test_connection.py
@@ -48,14 +48,17 @@ class TestInstantiation(unittest.TestCase):
         with self.mock_connection:
             manager = Manager()
             self.assertEqual(self.connection, str(manager.engine.url))
+            manager.engine.dispose()
 
     def test_instantiate_manager_positional(self):
         manager = Manager(self.connection)
         self.assertEqual(self.connection, str(manager.engine.url))
+        manager.engine.dispose()
 
     def test_instantiate_manager_positional_with_keyword(self):
         manager = Manager(self.connection, echo=False)
         self.assertEqual(self.connection, str(manager.engine.url))
+        manager.engine.dispose()
 
     def test_instantiate_manager_fail_positional(self):
         with self.assertRaises(ValueError):
@@ -64,6 +67,7 @@ class TestInstantiation(unittest.TestCase):
     def test_instantiate_manager_keyword(self):
         manager = Manager(connection=self.connection)
         self.assertEqual(self.connection, str(manager.engine.url))
+        manager.engine.dispose()
 
     def test_instantiate_manager_connection_fail_too_many_keyword(self):
         with self.assertRaises(ValueError):

--- a/tests/test_parse/test_parse_control.py
+++ b/tests/test_parse/test_parse_control.py
@@ -316,11 +316,11 @@ class TestParseControl2(TestParseControl):
         self.assertEqual({}, self.parser.annotations)
 
     def test_reset_citation(self):
-        s1_identifier = str(randint(0, 1e7))
+        s1_identifier = str(randint(0, 10**7))
         s1 = 'SET Citation = {{"PubMed","Test Reference 1","{}"}}'.format(s1_identifier)
         s2 = 'SET Evidence = "d"'
 
-        s3_identifier = str(randint(0, 1e7))
+        s3_identifier = str(randint(0, 10**7))
         s3 = 'SET Citation = {{"PubMed","Test Reference 2","{}"}}'.format(s3_identifier)
         _test_evidence = n()
         s4 = 'SET Evidence = "{}"'.format(_test_evidence)
@@ -346,7 +346,7 @@ class TestParseControl2(TestParseControl):
         self.assertFalse(self.parser.citation_is_set)
 
     def test_set_regex(self):
-        v = str(randint(0, 1e5))
+        v = str(randint(0, 10**5))
         s = [SET_CITATION_TEST, f'SET CustomRegex = "{v}"']
         self.parser.parse_lines(s)
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,10 @@ envlist =
 commands =
     {[testenv:doctests]commands}
     coverage run -p -m pytest --durations=20 {posargs:tests}
-passenv = PYBEL_TEST_CONNECTOR PYBEL_TEST_CONNECTION HOME
+passenv =
+    PYBEL_TEST_CONNECTOR
+    PYBEL_TEST_CONNECTION
+    HOME
 deps =
     coverage
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -135,6 +135,10 @@ extras =
     docs
     jupyter
     grounding
+allowlist_externals =
+    mkdir
+    cp
+    cat
 commands =
     mkdir -p {envtmpdir}
     cp -r source {envtmpdir}/source


### PR DESCRIPTION
This PR updates some fairly simple things in the package to make it work on recent Python versions. This was prompted by errors in INDRA tests, in particular, the usage of `pkg_resources` in `pybel`. Other issues that surfaced include various renamed pyparsing functions (lot of changes but just renaming), minor changes to pandas usage, and some linting. Also updated some things where PyOBO changed.

All jobs pass on Python 3.10-3.13.